### PR TITLE
devops: removed `test.nest` dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,9 +34,8 @@ Suggests:
     rmarkdown,
     scda.2021(>= 0.1.1),
     scda(>= 0.1.1),
-    test.nest (>= 0.2.11),
     testthat (>= 2.0)
-VignetteBuilder: 
+VignetteBuilder:
     knitr
 Encoding: UTF-8
 LazyData: true

--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -20,9 +20,6 @@ upstream_repos:
   insightsengineering/utils.nest:
     repo: insightsengineering/utils.nest
     host: https://github.com
-  insightsengineering/test.nest:
-    repo: insightsengineering/test.nest
-    host: https://github.com
   insightsengineering/scda:
     repo: insightsengineering/scda
     host: https://github.com

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -1,3 +1,0 @@
-library(test.nest)
-
-test_all()


### PR DESCRIPTION
Related to insightsengineering/coredev-tasks#70
