### PR TITLE
Fix waterfall

### DIFF
--- a/R/tm_g_waterfall.R
+++ b/R/tm_g_waterfall.R
@@ -467,7 +467,7 @@ srv_g_waterfall <- function(input,
         bar_color_opt = .(if (length(bar_color_var) == 0) {
           NULL
         } else if (length(bar_color_var) > 0 & all(unique(anl[[bar_color_var]]) %in% names(bar_color_opt)) == T) {
-          .(bar_color_opt)
+          bar_color_opt
         } else {
           NULL
         }),


### PR DESCRIPTION
Closes insightsengineering/coredev-tasks#278 

This was stupidly difficult to find - this fixes the NOTE and also the waterfall when using `bar_color_opt`

Check this app and its show r code (and also remove the `bar_color_opt` argument to check it's still working)

Related to https://github.com/insightsengineering/teal.osprey/issues/89

```
ADSL <- rADSL
ADRS <- rADRS
ADTR <- rADTR

ADSL$SEX <- factor(ADSL$SEX, levels = unique(ADSL$SEX))

x <- teal::init(
  data = cdisc_data(
    cdisc_dataset("ADSL", ADSL,
      code = "ADSL <- rADSL
              ADSL$SEX <- factor(ADSL$SEX, levels = unique(ADSL$SEX))"
    ),
    cdisc_dataset("ADRS", ADRS, code = "ADRS <- rADRS"),
    cdisc_dataset("ADTR", ADTR,
      code = " ADTR <- rADTR",
      c("STUDYID", "USUBJID", "PARAMCD", "AVISIT")
    ),
    check = TRUE
  ),
  modules = root_modules(
    tm_g_waterfall(
      label = "Waterfall",
      dataname_tr = "ADTR",
      dataname_rs = "ADRS",
      bar_paramcd = choices_selected(c("SLDINV"), "SLDINV"),
      bar_var = choices_selected(c("PCHG", "AVAL"), "PCHG"),
      bar_color_var = choices_selected(c("SEX"), "SEX"),
      bar_color_opt = c("F" = "tomato", "M" = "skyblue3", "U" = "darkgreen"),
      sort_var = choices_selected(c("ARMCD", "SEX"), NULL),
      add_label_var_sl = choices_selected(c("SEX", "EOSDY"), NULL),
      add_label_paramcd_rs = choices_selected(c("BESRSPI", "OBJRSPI"), NULL),
      anno_txt_var_sl = choices_selected(c("SEX", "ARMCD", "BMK1", "BMK2"), NULL),
      anno_txt_paramcd_rs = choices_selected(c("BESRSPI", "OBJRSPI"), NULL),
      facet_var = choices_selected(c("SEX", "ARMCD", "STRATA1", "STRATA2"), NULL),
      href_line = "-30, 20"
    )
  )
)

shinyApp(x$ui, x$server)
```