### PR TITLE
docs

### DIFF
--- a/R/argument_convention.R
+++ b/R/argument_convention.R
@@ -10,7 +10,7 @@
 #' `@inheritParams argument_convention`
 #'
 #' @param label (`character(1)`)\cr
-#'  menu item label of the module in the teal app
+#'  menu item label of the module in the teal app.
 #'
 #' @param dataname (\code{character(1)})\cr
 #'  analysis data used in the teal module, needs to be
@@ -26,7 +26,7 @@
 #'  See [teal::choices_selected()] for details.
 #'
 #' @param fontsize (`numeric(1)` or `numeric(3)`)\cr
-#'  Defines initial font-size it's possible range. `fontsize` is set for
+#'  Defines initial possible range of font-size. `fontsize` is set for
 #'  [teal::optionalSliderInputValMinMax()] which controls font-size in the output
 #'  plot.
 #'
@@ -36,7 +36,7 @@
 #' @param plot_width (`numeric(3)`)\cr
 #'  vector to indicate default value, minimum and maximum values.
 #'
-#' @return the [teal::module()] object
+#' @return the [teal::module()] object.
 #'
 #' @name argument_convention
 #'

--- a/R/tm_g_ae_oview.R
+++ b/R/tm_g_ae_oview.R
@@ -7,8 +7,6 @@
 #' @param flag_var_anl ([`teal::choices_selected`])
 #'   `choices_selected` object with variables used to count adverse event
 #'   sub-groups (e.g. Serious events, Related events, etc.)
-#' @param fontsize (`numeric`) vector with 3 values, selected font size and font size range,
-#' default is \code{c(5, 3, 7)}
 #'
 #' @inherit argument_convention return
 #'

--- a/man/argument_convention.Rd
+++ b/man/argument_convention.Rd
@@ -5,7 +5,7 @@
 \title{Standard Arguments}
 \arguments{
 \item{label}{(\code{character(1)})\cr
-menu item label of the module in the teal app}
+menu item label of the module in the teal app.}
 
 \item{dataname}{(\code{character(1)})\cr
 analysis data used in the teal module, needs to be
@@ -21,7 +21,7 @@ variable value designating the studied parameter.
 See \code{\link[teal:choices_selected]{teal::choices_selected()}} for details.}
 
 \item{fontsize}{(\code{numeric(1)} or \code{numeric(3)})\cr
-Defines initial font-size it's possible range. \code{fontsize} is set for
+Defines initial possible range of font-size. \code{fontsize} is set for
 \code{\link[teal:optionalSliderInputValMinMax]{teal::optionalSliderInputValMinMax()}} which controls font-size in the output
 plot.}
 
@@ -32,7 +32,7 @@ vector to indicate default value, minimum and maximum values.}
 vector to indicate default value, minimum and maximum values.}
 }
 \value{
-the \code{\link[teal:module]{teal::module()}} object
+the \code{\link[teal:module]{teal::module()}} object.
 }
 \description{
 The documentation to this function lists all the arguments in teal modules

--- a/man/tm_g_ae_oview.Rd
+++ b/man/tm_g_ae_oview.Rd
@@ -16,7 +16,7 @@ tm_g_ae_oview(
 }
 \arguments{
 \item{label}{(\code{character(1)})\cr
-menu item label of the module in the teal app}
+menu item label of the module in the teal app.}
 
 \item{dataname}{(\code{character(1)})\cr
 analysis data used in the teal module, needs to be
@@ -31,8 +31,10 @@ details.}
 \code{choices_selected} object with variables used to count adverse event
 sub-groups (e.g. Serious events, Related events, etc.)}
 
-\item{fontsize}{(\code{numeric}) vector with 3 values, selected font size and font size range,
-default is \code{c(5, 3, 7)}}
+\item{fontsize}{(\code{numeric(1)} or \code{numeric(3)})\cr
+Defines initial possible range of font-size. \code{fontsize} is set for
+\code{\link[teal:optionalSliderInputValMinMax]{teal::optionalSliderInputValMinMax()}} which controls font-size in the output
+plot.}
 
 \item{plot_height}{(\code{numeric(3)})\cr
 vector to indicate default value, minimum and maximum values.}
@@ -41,7 +43,7 @@ vector to indicate default value, minimum and maximum values.}
 vector to indicate default value, minimum and maximum values.}
 }
 \value{
-the \code{\link[teal:module]{teal::module()}} object
+the \code{\link[teal:module]{teal::module()}} object.
 }
 \description{
 Display the AE overview plot as a shiny module

--- a/man/tm_g_ae_sub.Rd
+++ b/man/tm_g_ae_sub.Rd
@@ -16,7 +16,7 @@ tm_g_ae_sub(
 }
 \arguments{
 \item{label}{(\code{character(1)})\cr
-menu item label of the module in the teal app}
+menu item label of the module in the teal app.}
 
 \item{dataname}{(\code{character(1)})\cr
 analysis data used in the teal module, needs to be
@@ -37,12 +37,12 @@ vector to indicate default value, minimum and maximum values.}
 vector to indicate default value, minimum and maximum values.}
 
 \item{fontsize}{(\code{numeric(1)} or \code{numeric(3)})\cr
-Defines initial font-size it's possible range. \code{fontsize} is set for
+Defines initial possible range of font-size. \code{fontsize} is set for
 \code{\link[teal:optionalSliderInputValMinMax]{teal::optionalSliderInputValMinMax()}} which controls font-size in the output
 plot.}
 }
 \value{
-the \code{\link[teal:module]{teal::module()}} object
+the \code{\link[teal:module]{teal::module()}} object.
 }
 \description{
 Display the AE by subgroups plot as a teal module

--- a/man/tm_g_butterfly.Rd
+++ b/man/tm_g_butterfly.Rd
@@ -25,7 +25,7 @@ tm_g_butterfly(
 }
 \arguments{
 \item{label}{(\code{character(1)})\cr
-menu item label of the module in the teal app}
+menu item label of the module in the teal app.}
 
 \item{dataname}{(\code{character(1)})\cr
 analysis data used in the teal module, needs to be
@@ -67,7 +67,7 @@ output to put the output into context. For example the
 \code{\link[shiny]{helpText}} elements are useful.}
 }
 \value{
-the \code{\link[teal:module]{teal::module()}} object
+the \code{\link[teal:module]{teal::module()}} object.
 }
 \description{
 Display butterfly plot as a shiny module

--- a/man/tm_g_events_term_id.Rd
+++ b/man/tm_g_events_term_id.Rd
@@ -16,7 +16,7 @@ tm_g_events_term_id(
 }
 \arguments{
 \item{label}{(\code{character(1)})\cr
-menu item label of the module in the teal app}
+menu item label of the module in the teal app.}
 
 \item{dataname}{(\code{character(1)})\cr
 analysis data used in the teal module, needs to be
@@ -31,7 +31,7 @@ names that can be used as \code{arm_var}. See \code{\link[teal:choices_selected]
 details.}
 
 \item{fontsize}{(\code{numeric(1)} or \code{numeric(3)})\cr
-Defines initial font-size it's possible range. \code{fontsize} is set for
+Defines initial possible range of font-size. \code{fontsize} is set for
 \code{\link[teal:optionalSliderInputValMinMax]{teal::optionalSliderInputValMinMax()}} which controls font-size in the output
 plot.}
 
@@ -42,7 +42,7 @@ vector to indicate default value, minimum and maximum values.}
 vector to indicate default value, minimum and maximum values.}
 }
 \value{
-the \code{\link[teal:module]{teal::module()}} object
+the \code{\link[teal:module]{teal::module()}} object.
 }
 \description{
 Display Events by Term plot as a shiny module

--- a/man/tm_g_heat_bygrade.Rd
+++ b/man/tm_g_heat_bygrade.Rd
@@ -23,7 +23,7 @@ tm_g_heat_bygrade(
 }
 \arguments{
 \item{label}{(\code{character(1)})\cr
-menu item label of the module in the teal app}
+menu item label of the module in the teal app.}
 
 \item{sl_dataname}{(\code{character}) subject level dataset name,
 needs to be available in the list passed to the \code{data}
@@ -57,7 +57,7 @@ This variable is a derived logical variable. Usually it can be derived from \cod
 specify to \code{NA} if no concomitant medications data is available}
 
 \item{fontsize}{(\code{numeric(1)} or \code{numeric(3)})\cr
-Defines initial font-size it's possible range. \code{fontsize} is set for
+Defines initial possible range of font-size. \code{fontsize} is set for
 \code{\link[teal:optionalSliderInputValMinMax]{teal::optionalSliderInputValMinMax()}} which controls font-size in the output
 plot.}
 
@@ -68,7 +68,7 @@ vector to indicate default value, minimum and maximum values.}
 vector to indicate default value, minimum and maximum values.}
 }
 \value{
-the \code{\link[teal:module]{teal::module()}} object
+the \code{\link[teal:module]{teal::module()}} object.
 }
 \description{
 Display the heatmap by grade as a shiny module

--- a/man/tm_g_patient_profile.Rd
+++ b/man/tm_g_patient_profile.Rd
@@ -35,7 +35,7 @@ tm_g_patient_profile(
 }
 \arguments{
 \item{label}{(\code{character(1)})\cr
-menu item label of the module in the teal app}
+menu item label of the module in the teal app.}
 
 \item{patient_id}{(\code{choices_seleced}) unique subject ID variable}
 
@@ -127,7 +127,7 @@ output to put the output into context. For example the
 \code{\link[shiny]{helpText}} elements are useful.}
 }
 \value{
-the \code{\link[teal:module]{teal::module()}} object
+the \code{\link[teal:module]{teal::module()}} object.
 }
 \description{
 Display patient profile plot as a shiny module

--- a/man/tm_g_spiderplot.Rd
+++ b/man/tm_g_spiderplot.Rd
@@ -26,7 +26,7 @@ tm_g_spiderplot(
 }
 \arguments{
 \item{label}{(\code{character(1)})\cr
-menu item label of the module in the teal app}
+menu item label of the module in the teal app.}
 
 \item{dataname}{(\code{character(1)})\cr
 analysis data used in the teal module, needs to be
@@ -70,7 +70,7 @@ output to put the output into context. For example the
 \code{\link[shiny]{helpText}} elements are useful.}
 }
 \value{
-the \code{\link[teal:module]{teal::module()}} object
+the \code{\link[teal:module]{teal::module()}} object.
 }
 \description{
 Display spider plot as a shiny module

--- a/man/tm_g_swimlane.Rd
+++ b/man/tm_g_swimlane.Rd
@@ -26,7 +26,7 @@ tm_g_swimlane(
 }
 \arguments{
 \item{label}{(\code{character(1)})\cr
-menu item label of the module in the teal app}
+menu item label of the module in the teal app.}
 
 \item{dataname}{analysis data used for plotting, needs to be available in the list passed to the \code{data}
 argument of \code{\link[teal]{init}}. If no markers are to be plotted in the module, "ADSL" should be
@@ -74,7 +74,7 @@ output to put the output into context. For example the
 \item{x_label}{the label of the x axis}
 }
 \value{
-the \code{\link[teal:module]{teal::module()}} object
+the \code{\link[teal:module]{teal::module()}} object.
 }
 \description{
 This is teal module that generates a swimlane plot (bar plot with markers) for ADaM data

--- a/man/tm_g_waterfall.Rd
+++ b/man/tm_g_waterfall.Rd
@@ -30,7 +30,7 @@ tm_g_waterfall(
 }
 \arguments{
 \item{label}{(\code{character(1)})\cr
-menu item label of the module in the teal app}
+menu item label of the module in the teal app.}
 
 \item{dataname_tr}{tumor burden analysis data used in teal module to plot as bar height, needs to
 be available in the list passed to the \code{data} argument of \code{\link[teal]{init}}}
@@ -93,7 +93,7 @@ output to put the output into context. For example the
 \code{\link[shiny]{helpText}} elements are useful.}
 }
 \value{
-the \code{\link[teal:module]{teal::module()}} object
+the \code{\link[teal:module]{teal::module()}} object.
 }
 \description{
 This is teal module that generates a waterfall plot for ADaM data

--- a/man/ui_g_decorate.Rd
+++ b/man/ui_g_decorate.Rd
@@ -20,7 +20,7 @@ to the module who called it.}
 \item{footnotes}{(\code{character}) default footnotes}
 
 \item{fontsize}{(\code{numeric(1)} or \code{numeric(3)})\cr
-Defines initial font-size it's possible range. \code{fontsize} is set for
+Defines initial possible range of font-size. \code{fontsize} is set for
 \code{\link[teal:optionalSliderInputValMinMax]{teal::optionalSliderInputValMinMax()}} which controls font-size in the output
 plot.}
 }


### PR DESCRIPTION
closes #95 

The `fontsize` doc in tm_g_ae_oview is superfluous as it should be inherited from argument_convention, so its removed 