### PR TITLE
214 review documentation after chunks->qenv transition

### DIFF
--- a/R/tm_g_swimlane.R
+++ b/R/tm_g_swimlane.R
@@ -40,8 +40,8 @@
 #' library(dplyr)
 #' library(nestcolor)
 #'
-#' ADSL <- rADSL
-#' ADRS <- rADRS
+#' ADSL <- osprey::rADSL
+#' ADRS <- osprey::rADRS
 #'
 #' ADRS <- ADRS %>%
 #'   dplyr::filter(PARAMCD == "LSTASDI" & DCSREAS == "Death") %>%
@@ -71,7 +71,7 @@
 #'       ),
 #'       bar_color_var = teal.transform::choices_selected(
 #'         selected = "EOSSTT",
-#'         choices = c("EOSSTT", "ARM", "ARMCD", "ACTARM", "ACTARMCD", "AGEGR1", "SEX")
+#'         choices = c("EOSSTT", "ARM", "ARMCD", "ACTARM", "ACTARMCD", "SEX")
 #'       ),
 #'       sort_var = teal.transform::choices_selected(
 #'         selected = "ACTARMCD",

--- a/R/tm_g_waterfall.R
+++ b/R/tm_g_waterfall.R
@@ -48,9 +48,9 @@
 #'
 #' @examples
 #' library(nestcolor)
-#' ADSL <- rADSL
-#' ADRS <- rADRS
-#' ADTR <- rADTR
+#' ADSL <- osprey::rADSL
+#' ADRS <- osprey::rADRS
+#' ADTR <- osprey::rADTR
 #'
 #' ADSL$SEX <- factor(ADSL$SEX, levels = unique(ADSL$SEX))
 #'

--- a/man/tm_g_swimlane.Rd
+++ b/man/tm_g_swimlane.Rd
@@ -86,8 +86,8 @@ This is teal module that generates a \code{swimlane} plot (bar plot with markers
 library(dplyr)
 library(nestcolor)
 
-ADSL <- rADSL
-ADRS <- rADRS
+ADSL <- osprey::rADSL
+ADRS <- osprey::rADRS
 
 ADRS <- ADRS \%>\%
   dplyr::filter(PARAMCD == "LSTASDI" & DCSREAS == "Death") \%>\%
@@ -117,7 +117,7 @@ app <- init(
       ),
       bar_color_var = teal.transform::choices_selected(
         selected = "EOSSTT",
-        choices = c("EOSSTT", "ARM", "ARMCD", "ACTARM", "ACTARMCD", "AGEGR1", "SEX")
+        choices = c("EOSSTT", "ARM", "ARMCD", "ACTARM", "ACTARMCD", "SEX")
       ),
       sort_var = teal.transform::choices_selected(
         selected = "ACTARMCD",

--- a/man/tm_g_waterfall.Rd
+++ b/man/tm_g_waterfall.Rd
@@ -101,9 +101,9 @@ This is teal module that generates a waterfall plot for \code{ADaM} data
 }
 \examples{
 library(nestcolor)
-ADSL <- rADSL
-ADRS <- rADRS
-ADTR <- rADTR
+ADSL <- osprey::rADSL
+ADRS <- osprey::rADRS
+ADTR <- osprey::rADTR
 
 ADSL$SEX <- factor(ADSL$SEX, levels = unique(ADSL$SEX))
 


### PR DESCRIPTION
This closes #204 

@gogonzo there is one example that fails - #215 - besides that they all run fine. There is no `teal.code::chunks` narration exposed in examples nor vignettes. Also the `teal.code` was already at 0.3.0 so no need to update DESCRIPTION file. I don't think I am able to resolve #215 even though I tried a couple of times.