### PR TITLE
Replace TealData with teal_data in the docs

### DIFF
--- a/R/tm_g_ae_oview.R
+++ b/R/tm_g_ae_oview.R
@@ -16,77 +16,51 @@
 #' @export
 #'
 #' @examples
-#' library(nestcolor)
+#' data <- cdisc_data() |>
+#'   within(library(nestcolor)) |>
+#'   within({
+#'     ADSL <- rADSL
+#'     ADAE <- rADAE
+#'     add_event_flags <- function(dat) {
+#'       dat <- dat |>
+#'         mutate(
+#'           TMPFL_SER = AESER == "Y",
+#'           TMPFL_REL = AEREL == "Y",
+#'           TMPFL_GR5 = AETOXGR == "5",
+#'           AEREL1 = (AEREL == "Y" & ACTARM == "A: Drug X"),
+#'           AEREL2 = (AEREL == "Y" & ACTARM == "B: Placebo")
+#'         )
+#'       labels <- c(
+#'         "Serious AE", "Related AE", "Grade 5 AE",
+#'         "AE related to A: Drug X", "AE related to B: Placebo"
+#'       )
+#'       cols <- c("TMPFL_SER", "TMPFL_REL", "TMPFL_GR5", "AEREL1", "AEREL2")
+#'       for (i in seq_along(labels)) {
+#'         attr(dat[[cols[i]]], "label") <- labels[i]
+#'       }
+#'       dat
+#'     }
+#'     ADAE <- add_event_flags(ADAE)
+#'   })
 #'
-#' ADSL <- osprey::rADSL
-#' ADAE <- osprey::rADAE
+#' datanames(data) <- c("ADSL", "ADAE")
+#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
 #'
-#' # Add additional dummy causality flags.
-#' add_event_flags <- function(dat) {
-#'   dat <- dat %>%
-#'     dplyr::mutate(
-#'       TMPFL_SER = AESER == "Y",
-#'       TMPFL_REL = AEREL == "Y",
-#'       TMPFL_GR5 = AETOXGR == "5",
-#'       AEREL1 = (AEREL == "Y" & ACTARM == "A: Drug X"),
-#'       AEREL2 = (AEREL == "Y" & ACTARM == "B: Placebo")
-#'     )
-#'   labels <- c(
-#'     "Serious AE", "Related AE", "Grade 5 AE",
-#'     "AE related to A: Drug X", "AE related to B: Placebo"
-#'   )
-#'   cols <- c("TMPFL_SER", "TMPFL_REL", "TMPFL_GR5", "AEREL1", "AEREL2")
-#'   for (i in seq_along(labels)) {
-#'     attr(dat[[cols[i]]], "label") <- labels[i]
-#'   }
-#'   dat
-#' }
-#' ADAE <- ADAE %>% add_event_flags()
+#' ADAE <- data[["ADAE"]]
 #'
 #' app <- init(
-#'   data = cdisc_data(
-#'     cdisc_dataset("ADSL", ADSL, code = "ADSL <- osprey::rADSL"),
-#'     cdisc_dataset("ADAE", ADAE,
-#'       code =
-#'         "ADAE <- osprey::rADAE
-#'            add_event_flags <- function(dat) {
-#'              dat <- dat %>%
-#'                dplyr::mutate(
-#'                  TMPFL_SER = AESER == 'Y',
-#'                  TMPFL_REL = AEREL == 'Y',
-#'                  TMPFL_GR5 = AETOXGR == '5',
-#'                  AEREL1 = (AEREL == 'Y' & ACTARM == 'A: Drug X'),
-#'                  AEREL2 = (AEREL == 'Y' & ACTARM == 'B: Placebo')
-#'                )
-#'              labels <- c(
-#'                'Serious AE',
-#'                'Related AE',
-#'                'Grade 5 AE',
-#'                'AE related to A: Drug X',
-#'                'AE related to B: Placebo'
-#'              )
-#'              cols <- c('TMPFL_SER', 'TMPFL_REL', 'TMPFL_GR5', 'AEREL1', 'AEREL2')
-#'              for (i in seq_along(labels)) {
-#'               attr(dat[[cols[i]]], 'label') <- labels[i]
-#'              }
-#'              dat
-#'            }
-#'            # Generating user-defined event flags.
-#'            ADAE <- ADAE %>% add_event_flags()"
-#'     ),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = modules(
 #'     tm_g_ae_oview(
 #'       label = "AE Overview",
 #'       dataname = "ADAE",
-#'       arm_var = teal.transform::choices_selected(
+#'       arm_var = choices_selected(
 #'         selected = "ACTARM",
 #'         choices = c("ACTARM", "ACTARMCD")
 #'       ),
-#'       flag_var_anl = teal.transform::choices_selected(
+#'       flag_var_anl = choices_selected(
 #'         selected = "AEREL1",
-#'         choices = teal.transform::variable_choices(
+#'         choices = variable_choices(
 #'           ADAE,
 #'           c("TMPFL_SER", "TMPFL_REL", "TMPFL_GR5", "AEREL1", "AEREL2")
 #'         ),
@@ -98,6 +72,7 @@
 #' if (interactive()) {
 #'   shinyApp(app$ui, app$server)
 #' }
+#'
 tm_g_ae_oview <- function(label,
                           dataname,
                           arm_var,

--- a/R/tm_g_ae_sub.R
+++ b/R/tm_g_ae_sub.R
@@ -17,16 +17,18 @@
 #' @export
 #'
 #' @examples
-#' # Example using stream (ADaM) dataset
-#' ADSL <- osprey::rADSL
-#' ADAE <- osprey::rADAE
+# Example using stream (ADaM) dataset
+#' data <- cdisc_data() |>
+#'   within({
+#'     ADSL <- rADSL
+#'     ADAE <- rADAE
+#'   })
+#'
+#' datanames(data) <- c("ADSL", "ADAE")
+#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
 #'
 #' app <- init(
-#'   data = cdisc_data(
-#'     cdisc_dataset("ADSL", ADSL, code = "ADSL <- osprey::rADSL"),
-#'     cdisc_dataset("ADAE", ADAE, code = "ADAE <- osprey::rADAE"),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = modules(
 #'     tm_g_ae_sub(
 #'       label = "AE by Subgroup",
@@ -46,6 +48,7 @@
 #' if (interactive()) {
 #'   shinyApp(app$ui, app$server)
 #' }
+#'
 tm_g_ae_sub <- function(label,
                         dataname,
                         arm_var,

--- a/R/tm_g_butterfly.R
+++ b/R/tm_g_butterfly.R
@@ -40,69 +40,60 @@
 #' @template author_liaoc10
 #'
 #' @examples
+# Example using stream (ADaM) dataset
+#' data <- cdisc_data() |>
+#'   within({
+#'     library(dplyr)
+#'     library(nestcolor)
+#'   }) |>
+#'   within({
+#'     set.seed(23)
+#'     ADSL <- rADSL
+#'     ADAE <- rADAE
+#'     ADSL <- mutate(ADSL, DOSE = paste(sample(1:3, n(), replace = TRUE), "UG"))
+#'     ADAE <- mutate(
+#'       ADAE,
+#'       flag1 = ifelse(AETOXGR == 1, 1, 0),
+#'       flag2 = ifelse(AETOXGR == 2, 1, 0),
+#'       flag3 = ifelse(AETOXGR == 3, 1, 0),
+#'       flag1_filt = rep("Y", n())
+#'     )
+#'   })
 #'
-#' # Example using stream (ADaM) dataset
-#' library(dplyr)
-#' library(nestcolor)
-#'
-#' set.seed(23)
-#' ADSL <- osprey::rADSL
-#' ADAE <- osprey::rADAE
-#' ADSL <- mutate(ADSL, DOSE = paste(sample(1:3, n(), replace = TRUE), "UG"))
-#' ADAE <- mutate(
-#'   ADAE,
-#'   flag1 = ifelse(AETOXGR == 1, 1, 0),
-#'   flag2 = ifelse(AETOXGR == 2, 1, 0),
-#'   flag3 = ifelse(AETOXGR == 3, 1, 0),
-#'   flag1_filt = rep("Y", n())
-#' )
+#' datanames(data) <- c("ADSL", "ADAE")
+#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
 #'
 #' app <- init(
-#'   data = cdisc_data(
-#'     cdisc_dataset("ADSL", ADSL,
-#'       code = "ADSL <- osprey::rADSL
-#'               set.seed(23)
-#'               ADSL <- mutate(ADSL, DOSE = paste(sample(1:3, n(), replace = TRUE), 'UG'))"
-#'     ),
-#'     cdisc_dataset("ADAE", ADAE,
-#'       code = "ADAE <- osprey::rADAE
-#'               ADAE <- mutate(ADAE,
-#'               flag1 = ifelse(AETOXGR == 1, 1, 0),
-#'               flag2 = ifelse(AETOXGR == 2, 1, 0),
-#'               flag3 = ifelse(AETOXGR == 3, 1, 0),
-#'               flag1_filt = rep('Y', n()))"
-#'     ),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = modules(
 #'     tm_g_butterfly(
 #'       label = "Butterfly Plot",
 #'       dataname = "ADAE",
-#'       right_var = teal.transform::choices_selected(
+#'       right_var = choices_selected(
 #'         selected = "SEX",
 #'         choices = c("SEX", "ARM", "RACE")
 #'       ),
-#'       left_var = teal.transform::choices_selected(
+#'       left_var = choices_selected(
 #'         selected = "RACE",
 #'         choices = c("SEX", "ARM", "RACE")
 #'       ),
-#'       category_var = teal.transform::choices_selected(
+#'       category_var = choices_selected(
 #'         selected = "AEBODSYS",
 #'         choices = c("AEDECOD", "AEBODSYS")
 #'       ),
-#'       color_by_var = teal.transform::choices_selected(
+#'       color_by_var = choices_selected(
 #'         selected = "AETOXGR",
 #'         choices = c("AETOXGR", "None")
 #'       ),
-#'       count_by_var = teal.transform::choices_selected(
+#'       count_by_var = choices_selected(
 #'         selected = "# of patients",
 #'         choices = c("# of patients", "# of AEs")
 #'       ),
-#'       facet_var = teal.transform::choices_selected(
+#'       facet_var = choices_selected(
 #'         selected = NULL,
 #'         choices = c("RACE", "SEX", "ARM")
 #'       ),
-#'       sort_by_var = teal.transform::choices_selected(
+#'       sort_by_var = choices_selected(
 #'         selected = "count",
 #'         choices = c("count", "alphabetical")
 #'       ),

--- a/R/tm_g_events_term_id.R
+++ b/R/tm_g_events_term_id.R
@@ -18,29 +18,30 @@
 #' @author Molly He (hey59) \email{hey59@gene.com}
 #'
 #' @examples
-#' library(nestcolor)
+#' data <- cdisc_data() |>
+#'   within(library(nestcolor)) |>
+#'   within({
+#'     ADSL <- rADSL
+#'     ADAE <- rADAE
+#'   })
 #'
-#' ADSL <- osprey::rADSL
-#' ADAE <- osprey::rADAE
+#' datanames(data) <- c("ADSL", "ADAE")
+#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
 #'
 #' app <- init(
-#'   data = cdisc_data(
-#'     cdisc_dataset("ADSL", ADSL, code = "ADSL <- osprey::rADSL"),
-#'     cdisc_dataset("ADAE", ADAE, code = "ADAE <- osprey::rADAE"),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = modules(
 #'     tm_g_events_term_id(
 #'       label = "Common AE",
 #'       dataname = "ADAE",
-#'       term_var = teal.transform::choices_selected(
+#'       term_var = choices_selected(
 #'         selected = "AEDECOD",
 #'         choices = c(
 #'           "AEDECOD", "AETERM",
 #'           "AEHLT", "AELLT", "AEBODSYS"
 #'         )
 #'       ),
-#'       arm_var = teal.transform::choices_selected(
+#'       arm_var = choices_selected(
 #'         selected = "ACTARMCD",
 #'         choices = c("ACTARM", "ACTARMCD")
 #'       ),

--- a/R/tm_g_heat_bygrade.R
+++ b/R/tm_g_heat_bygrade.R
@@ -38,14 +38,16 @@
 #'   within({
 #'     library(dplyr)
 #'     library(nestcolor)
-#'     }) |>
+#'   }) |>
 #'   within({
 #'     ADSL <- rADSL %>% slice(1:30)
 #'     ADEX <- rADEX %>% filter(USUBJID %in% ADSL$USUBJID)
 #'     ADAE <- rADAE %>% filter(USUBJID %in% ADSL$USUBJID)
 #'     ADCM <- rADCM %>% filter(USUBJID %in% ADSL$USUBJID)
 #'     # This preprocess is only to force legacy standard on ADCM
-#'     ADCM <- ADCM %>% select(-starts_with("ATC")) %>% unique()
+#'     ADCM <- ADCM %>%
+#'       select(-starts_with("ATC")) %>%
+#'       unique()
 #'     # function to derive AVISIT from ADEX
 #'     add_visit <- function(data_need_visit) {
 #'       visit_dates <- ADEX %>%
@@ -67,7 +69,9 @@
 #'     ADAE <- add_visit(ADAE)
 #'     ADCM <- add_visit(ADCM)
 #'     # derive ongoing status variable for ADEX
-#'     ADEX <- ADEX %>% filter(PARCAT1 == "INDIVIDUAL") %>% mutate(ongo_status = (EOSSTT == "ONGOING"))
+#'     ADEX <- ADEX %>%
+#'       filter(PARCAT1 == "INDIVIDUAL") %>%
+#'       mutate(ongo_status = (EOSSTT == "ONGOING"))
 #'   })
 #'
 #' datanames(data) <- c("ADSL", "ADEX", "ADAE", "ADCM")

--- a/R/tm_g_heat_bygrade.R
+++ b/R/tm_g_heat_bygrade.R
@@ -34,61 +34,22 @@
 #' @export
 #'
 #' @examples
-#' library(dplyr)
-#' library(nestcolor)
-#' ADSL <- osprey::rADSL %>% slice(1:30)
-#' ADEX <- osprey::rADEX %>% filter(USUBJID %in% ADSL$USUBJID)
-#' ADAE <- osprey::rADAE %>% filter(USUBJID %in% ADSL$USUBJID)
-#' ADCM <- osprey::rADCM %>% filter(USUBJID %in% ADSL$USUBJID)
-#'
-#' # This preprocess is only to force legacy standard on ADCM
-#' ADCM <- ADCM %>%
-#'   select(-starts_with("ATC")) %>%
-#'   unique()
-#'
-#' # function to derive AVISIT from ADEX
-#' add_visit <- function(data_need_visit) {
-#'   visit_dates <- ADEX %>%
-#'     filter(PARAMCD == "DOSE") %>%
-#'     distinct(USUBJID, AVISIT, ASTDTM) %>%
-#'     group_by(USUBJID) %>%
-#'     arrange(ASTDTM) %>%
-#'     mutate(next_vis = lead(ASTDTM), is_last = ifelse(is.na(next_vis), TRUE, FALSE)) %>%
-#'     rename(this_vis = ASTDTM)
-#'   data_visit <- data_need_visit %>%
-#'     select(USUBJID, ASTDTM) %>%
-#'     left_join(visit_dates, by = "USUBJID") %>%
-#'     filter(ASTDTM > this_vis & (ASTDTM < next_vis | is_last == TRUE)) %>%
-#'     left_join(data_need_visit) %>%
-#'     distinct()
-#'   return(data_visit)
-#' }
-#' # derive AVISIT for ADAE and ADCM
-#' ADAE <- add_visit(ADAE)
-#' ADCM <- add_visit(ADCM)
-#' # derive ongoing status variable for ADEX
-#' ADEX <- ADEX %>%
-#'   filter(PARCAT1 == "INDIVIDUAL") %>%
-#'   mutate(ongo_status = (EOSSTT == "ONGOING"))
-#'
-#' app <- init(
-#'   data = cdisc_data(
-#'     cdisc_dataset("ADSL", ADSL),
-#'     cdisc_dataset("ADEX", ADEX),
-#'     cdisc_dataset("ADAE", ADAE),
-#'     cdisc_dataset("ADCM", ADCM, keys = c("STUDYID", "USUBJID", "ASTDTM", "CMSEQ", "CMDECOD")),
-#'     code = "
-#'     ADSL <- osprey::rADSL %>% slice(1:30)
-#'     ADEX <- osprey::rADEX %>% filter(USUBJID %in% ADSL$USUBJID)
-#'     ADAE <- osprey::rADAE %>% filter(USUBJID %in% ADSL$USUBJID)
-#'     ADCM <- osprey::rADCM %>% filter(USUBJID %in% ADSL$USUBJID)
-#'     ADCM <- ADCM %>% select(-starts_with(\"ATC\")) %>% unique()
-#'     ADEX  <- ADEX %>%
-#'       filter(PARCAT1 == 'INDIVIDUAL') %>%
-#'       mutate(ongo_status = (EOSSTT == 'ONGOING'))
+#' data <- cdisc_data() |>
+#'   within({
+#'     library(dplyr)
+#'     library(nestcolor)
+#'     }) |>
+#'   within({
+#'     ADSL <- rADSL %>% slice(1:30)
+#'     ADEX <- rADEX %>% filter(USUBJID %in% ADSL$USUBJID)
+#'     ADAE <- rADAE %>% filter(USUBJID %in% ADSL$USUBJID)
+#'     ADCM <- rADCM %>% filter(USUBJID %in% ADSL$USUBJID)
+#'     # This preprocess is only to force legacy standard on ADCM
+#'     ADCM <- ADCM %>% select(-starts_with("ATC")) %>% unique()
+#'     # function to derive AVISIT from ADEX
 #'     add_visit <- function(data_need_visit) {
 #'       visit_dates <- ADEX %>%
-#'         filter(PARAMCD == 'DOSE') %>%
+#'         filter(PARAMCD == "DOSE") %>%
 #'         distinct(USUBJID, AVISIT, ASTDTM) %>%
 #'         group_by(USUBJID) %>%
 #'         arrange(ASTDTM) %>%
@@ -96,16 +57,26 @@
 #'         rename(this_vis = ASTDTM)
 #'       data_visit <- data_need_visit %>%
 #'         select(USUBJID, ASTDTM) %>%
-#'         left_join(visit_dates, by = 'USUBJID') %>%
+#'         left_join(visit_dates, by = "USUBJID") %>%
 #'         filter(ASTDTM > this_vis & (ASTDTM < next_vis | is_last == TRUE)) %>%
-#'         left_join(data_need_visit) %>% distinct()
+#'         left_join(data_need_visit) %>%
+#'         distinct()
 #'       return(data_visit)
 #'     }
+#'     # derive AVISIT for ADAE and ADCM
 #'     ADAE <- add_visit(ADAE)
 #'     ADCM <- add_visit(ADCM)
-#'     ",
-#'     check = TRUE
-#'   ),
+#'     # derive ongoing status variable for ADEX
+#'     ADEX <- ADEX %>% filter(PARCAT1 == "INDIVIDUAL") %>% mutate(ongo_status = (EOSSTT == "ONGOING"))
+#'   })
+#'
+#' datanames(data) <- c("ADSL", "ADEX", "ADAE", "ADCM")
+#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+#'
+#' ADCM <- data[["ADCM"]]
+#'
+#' app <- init(
+#'   data = data,
 #'   modules = modules(
 #'     tm_g_heat_bygrade(
 #'       label = "Heatmap by grade",
@@ -113,27 +84,27 @@
 #'       ex_dataname = "ADEX",
 #'       ae_dataname = "ADAE",
 #'       cm_dataname = "ADCM",
-#'       id_var = teal.transform::choices_selected(
+#'       id_var = choices_selected(
 #'         selected = "USUBJID",
 #'         choices = c("USUBJID", "SUBJID")
 #'       ),
-#'       visit_var = teal.transform::choices_selected(
+#'       visit_var = choices_selected(
 #'         selected = "AVISIT",
 #'         choices = c("AVISIT")
 #'       ),
-#'       ongo_var = teal.transform::choices_selected(
+#'       ongo_var = choices_selected(
 #'         selected = "ongo_status",
 #'         choices = c("ongo_status")
 #'       ),
-#'       anno_var = teal.transform::choices_selected(
+#'       anno_var = choices_selected(
 #'         selected = c("SEX", "COUNTRY"),
 #'         choices = c("SEX", "COUNTRY", "USUBJID")
 #'       ),
-#'       heat_var = teal.transform::choices_selected(
+#'       heat_var = choices_selected(
 #'         selected = "AETOXGR",
 #'         choices = c("AETOXGR")
 #'       ),
-#'       conmed_var = teal.transform::choices_selected(
+#'       conmed_var = choices_selected(
 #'         selected = "CMDECOD",
 #'         choices = c("CMDECOD")
 #'       ),
@@ -144,6 +115,7 @@
 #' if (interactive()) {
 #'   shinyApp(app$ui, app$server)
 #' }
+#'
 tm_g_heat_bygrade <- function(label,
                               sl_dataname,
                               ex_dataname,

--- a/R/tm_g_patient_profile.R
+++ b/R/tm_g_patient_profile.R
@@ -62,70 +62,31 @@
 #' @export
 #'
 #' @examples
-#' library(nestcolor)
+#' data <- cdisc_data() |>
+#'   within(library(nestcolor)) |>
+#'   within({
+#'     ADSL <- rADSL
+#'     ADAE <- rADAE %>% mutate(ASTDT = as.Date(ASTDTM), AENDT = as.Date(AENDTM))
+#'     ADCM <- rADCM %>% mutate(ASTDT = as.Date(ASTDTM), AENDT = as.Date(AENDTM))
+#'     # The step below is to pre-process ADCM to legacy standard
+#'     ADCM <- ADCM %>% select(-starts_with("ATC")) %>% unique()
+#'     ADRS <- rADRS %>% mutate(ADT = as.Date(ADTM))
+#'     ADEX <- rADEX %>% mutate(ASTDT = as.Date(ASTDTM), AENDT = as.Date(AENDTM))
+#'     ADLB <- rADLB %>% mutate(ADT = as.Date(ADTM), LBSTRESN = as.numeric(LBSTRESC))
 #'
-#' ADSL <- osprey::rADSL
-#' ADAE <- osprey::rADAE %>%
-#'   mutate(
-#'     ASTDT = as.Date(ASTDTM),
-#'     AENDT = as.Date(AENDTM)
-#'   )
-#' ADCM <- osprey::rADCM %>%
-#'   mutate(
-#'     ASTDT = as.Date(ASTDTM),
-#'     AENDT = as.Date(AENDTM)
-#'   )
+#'   })
 #'
-#' # The step below is to pre-process ADCM to legacy standard
-#' ADCM <- ADCM %>%
-#'   select(-starts_with("ATC")) %>%
-#'   unique()
+#' datanames(data) <- c("ADSL", "ADAE", "ADCM", "ADRS", "ADEX", "ADLB")
+#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
 #'
-#' ADRS <- osprey::rADRS %>%
-#'   mutate(ADT = as.Date(ADTM))
-#' ADEX <- osprey::rADEX %>%
-#'   mutate(
-#'     ASTDT = as.Date(ASTDTM),
-#'     AENDT = as.Date(AENDTM)
-#'   )
-#' ADLB <- osprey::rADLB %>%
-#'   mutate(
-#'     ADT = as.Date(ADTM),
-#'     LBSTRESN = as.numeric(LBSTRESC)
-#'   )
+#' ADSL <- data[["ADSL"]]
 #'
 #' app <- init(
-#'   data = cdisc_data(
-#'     cdisc_dataset("ADSL", ADSL, code = "ADSL <- osprey::rADSL"),
-#'     cdisc_dataset("ADRS", ADRS, code = "ADRS <- osprey::rADRS %>% mutate(ADT = as.Date(ADTM))"),
-#'     cdisc_dataset("ADAE", ADAE,
-#'       code = "ADAE <- osprey::rADAE %>%
-#'               mutate(ASTDT = as.Date(ASTDTM),
-#'                      AENDT = as.Date(AENDTM))"
-#'     ),
-#'     cdisc_dataset("ADCM", ADCM,
-#'       code = "ADCM <- osprey::rADCM %>%
-#'               mutate(ASTDT = as.Date(ASTDTM),
-#'                      AENDT = as.Date(AENDTM))
-#'               ADCM <- ADCM %>% select(-starts_with(\"ATC\")) %>% unique()",
-#'       keys = c("STUDYID", "USUBJID", "ASTDTM", "CMSEQ", "CMDECOD")
-#'     ),
-#'     cdisc_dataset("ADLB", ADLB,
-#'       code = "ADLB <- osprey::rADLB %>%
-#'               mutate(ADT = as.Date(ADTM),
-#'                      LBSTRESN = as.numeric(LBSTRESC))"
-#'     ),
-#'     cdisc_dataset("ADEX", ADEX,
-#'       code = "ADEX <- osprey::rADEX %>%
-#'               mutate(ASTDT = as.Date(ASTDTM),
-#'                      AENDT = as.Date(AENDTM))"
-#'     ),
-#'     check = FALSE # set FALSE here to keep run time of example short, should be set to TRUE
-#'   ),
+#'   data = data,
 #'   modules = modules(
 #'     tm_g_patient_profile(
 #'       label = "Patient Profile Plot",
-#'       patient_id = teal.transform::choices_selected(
+#'       patient_id = choices_selected(
 #'         choices = unique(ADSL$USUBJID),
 #'         selected = unique(ADSL$USUBJID)[1]
 #'       ),
@@ -135,32 +96,32 @@
 #'       rs_dataname = "ADRS",
 #'       cm_dataname = "ADCM",
 #'       lb_dataname = "ADLB",
-#'       sl_start_date = teal.transform::choices_selected(
+#'       sl_start_date = choices_selected(
 #'         selected = "TRTSDTM",
 #'         choices = c("TRTSDTM", "RANDDT")
 #'       ),
-#'       ex_var = teal.transform::choices_selected(
+#'       ex_var = choices_selected(
 #'         selected = "PARCAT2",
 #'         choices = "PARCAT2"
 #'       ),
-#'       ae_var = teal.transform::choices_selected(
+#'       ae_var = choices_selected(
 #'         selected = "AEDECOD",
 #'         choices = c("AEDECOD", "AESOC")
 #'       ),
-#'       ae_line_col_var = teal.transform::choices_selected(
+#'       ae_line_col_var = choices_selected(
 #'         selected = "AESER",
 #'         choices = c("AESER", "AEREL")
 #'       ),
 #'       ae_line_col_opt = c("Y" = "red", "N" = "blue"),
-#'       rs_var = teal.transform::choices_selected(
+#'       rs_var = choices_selected(
 #'         selected = "PARAMCD",
 #'         choices = "PARAMCD"
 #'       ),
-#'       cm_var = teal.transform::choices_selected(
+#'       cm_var = choices_selected(
 #'         selected = "CMDECOD",
 #'         choices = c("CMDECOD", "CMCAT")
 #'       ),
-#'       lb_var = teal.transform::choices_selected(
+#'       lb_var = choices_selected(
 #'         selected = "LBTESTCD",
 #'         choices = c("LBTESTCD", "LBCAT")
 #'       ),

--- a/R/tm_g_patient_profile.R
+++ b/R/tm_g_patient_profile.R
@@ -69,11 +69,12 @@
 #'     ADAE <- rADAE %>% mutate(ASTDT = as.Date(ASTDTM), AENDT = as.Date(AENDTM))
 #'     ADCM <- rADCM %>% mutate(ASTDT = as.Date(ASTDTM), AENDT = as.Date(AENDTM))
 #'     # The step below is to pre-process ADCM to legacy standard
-#'     ADCM <- ADCM %>% select(-starts_with("ATC")) %>% unique()
+#'     ADCM <- ADCM %>%
+#'       select(-starts_with("ATC")) %>%
+#'       unique()
 #'     ADRS <- rADRS %>% mutate(ADT = as.Date(ADTM))
 #'     ADEX <- rADEX %>% mutate(ASTDT = as.Date(ASTDTM), AENDT = as.Date(AENDTM))
 #'     ADLB <- rADLB %>% mutate(ADT = as.Date(ADTM), LBSTRESN = as.numeric(LBSTRESC))
-#'
 #'   })
 #'
 #' datanames(data) <- c("ADSL", "ADAE", "ADCM", "ADRS", "ADEX", "ADLB")

--- a/R/tm_g_spiderplot.R
+++ b/R/tm_g_spiderplot.R
@@ -25,52 +25,51 @@
 #' @template author_liaoc10
 #'
 #' @examples
-#'
 #' # Example using stream (ADaM) dataset
-#' library(dplyr)
-#' library(nestcolor)
+#' data <- cdisc_data() |>
+#'   within({
+#'     library(dplyr)
+#'     library(nestcolor)
+#'   }) |>
+#'   within({
+#'     ADSL <- rADSL
+#'     ADTR <- rADTR
+#'   })
 #'
-#' ADSL <- osprey::rADSL
-#' ADTR <- osprey::rADTR
+#' datanames(data) <- c("ADSL", "ADTR")
+#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
 #'
-#' app <- teal::init(
-#'   data = cdisc_data(
-#'     cdisc_dataset("ADSL", ADSL, code = "ADSL <- osprey::rADSL"),
-#'     cdisc_dataset("ADTR", ADTR,
-#'       code = "ADTR <- osprey::rADTR",
-#'       keys = c("STUDYID", "USUBJID", "PARAMCD", "AVISIT")
-#'     ),
-#'     check = TRUE
-#'   ),
+#' app <- init(
+#'   data = data,
 #'   modules = modules(
 #'     tm_g_spiderplot(
 #'       label = "Spider plot",
 #'       dataname = "ADTR",
-#'       paramcd = teal.transform::choices_selected(
+#'       paramcd = choices_selected(
 #'         choices = "SLDINV",
 #'         selected = "SLDINV"
 #'       ),
-#'       x_var = teal.transform::choices_selected(
+#'       x_var = choices_selected(
 #'         choices = "ADY",
 #'         selected = "ADY"
 #'       ),
-#'       y_var = teal.transform::choices_selected(
+#'       y_var = choices_selected(
 #'         choices = c("PCHG", "CHG", "AVAL"),
 #'         selected = "PCHG"
 #'       ),
-#'       marker_var = teal.transform::choices_selected(
+#'       marker_var = choices_selected(
 #'         choices = c("SEX", "RACE", "USUBJID"),
 #'         selected = "SEX"
 #'       ),
-#'       line_colorby_var = teal.transform::choices_selected(
+#'       line_colorby_var = choices_selected(
 #'         choices = c("SEX", "USUBJID", "RACE"),
 #'         selected = "SEX"
 #'       ),
-#'       xfacet_var = teal.transform::choices_selected(
+#'       xfacet_var = choices_selected(
 #'         choices = c("SEX", "ARM"),
 #'         selected = "SEX"
 #'       ),
-#'       yfacet_var = teal.transform::choices_selected(
+#'       yfacet_var = choices_selected(
 #'         choices = c("SEX", "ARM"),
 #'         selected = "ARM"
 #'       ),

--- a/R/tm_g_swimlane.R
+++ b/R/tm_g_swimlane.R
@@ -35,37 +35,29 @@
 #' @template author_qit3
 #'
 #' @examples
-#'
 #' # Example using stream (ADaM) dataset
-#' library(dplyr)
-#' library(nestcolor)
+#' data <- teal.data::cdisc_data() |>
+#'   within(library(dplyr)) |>
+#'   within(library(nestcolor)) |>
+#'   within(ADSL <- osprey::rADSL %>%
+#'     dplyr::mutate(TRTDURD = as.integer(TRTEDTM - TRTSDTM) + 1) %>%
+#'     dplyr::filter(STRATA1 == "A" & ARMCD == "ARM A")) |>
+#'   within(ADRS <- osprey::rADRS) |>
+#'   within(ADRS <- ADRS %>%
+#'     dplyr::filter(PARAMCD == "LSTASDI" & DCSREAS == "Death") %>%
+#'     mutate(AVALC = DCSREAS, ADY = EOSDY) %>%
+#'     base::rbind(ADRS %>% dplyr::filter(PARAMCD == "OVRINV" & AVALC != "NE")) %>%
+#'     arrange(USUBJID))
 #'
-#' ADSL <- osprey::rADSL %>%
-#'   dplyr::mutate(TRTDURD = as.integer(TRTEDTM - TRTSDTM) + 1) %>%
-#'   dplyr::filter(STRATA1 == "A" & ARMCD == "ARM A")
-#' ADRS <- osprey::rADRS
+#' teal.data::datanames(data) <- c("ADSL", "ADRS")
+#' teal.data::join_keys(data) <- teal.data::default_cdisc_join_keys[teal.data::datanames(data)]
 #'
-#' ADRS <- ADRS %>%
-#'   dplyr::filter(PARAMCD == "LSTASDI" & DCSREAS == "Death") %>%
-#'   mutate(AVALC = DCSREAS, ADY = EOSDY) %>%
-#'   base::rbind(ADRS %>% dplyr::filter(PARAMCD == "OVRINV" & AVALC != "NE")) %>%
-#'   arrange(USUBJID)
+#' ADSL <- data[["ADSL"]]
+#' ADRS <- data[["ADRS"]]
 #'
-#' app <- init(
-#'   data = cdisc_data(
-#'     cdisc_dataset("ADSL", ADSL, code = "ADSL <- osprey::rADSL %>%
-#'       dplyr::mutate(TRTDURD = as.integer(TRTEDTM - TRTSDTM) + 1) %>%
-#'       dplyr::filter(STRATA1 == 'A' & ARMCD == 'ARM A')"),
-#'     cdisc_dataset("ADRS", ADRS,
-#'       code = "ADRS <- rADRS
-#'               ADRS <- ADRS %>% dplyr::filter(PARAMCD == 'LSTASDI' & DCSREAS == 'Death') %>%
-#'                       mutate(AVALC = DCSREAS, ADY = EOSDY) %>%
-#'               rbind(ADRS %>% dplyr::filter(PARAMCD == 'OVRINV' & AVALC != 'NE')) %>%
-#'               arrange(USUBJID)"
-#'     ),
-#'     check = TRUE
-#'   ),
-#'   modules = modules(
+#' app <- teal::init(
+#'   data = data,
+#'   modules = teal::modules(
 #'     tm_g_swimlane(
 #'       label = "Swimlane Plot",
 #'       dataname = "ADRS",

--- a/R/tm_g_waterfall.R
+++ b/R/tm_g_waterfall.R
@@ -47,41 +47,35 @@
 #' @author houx14 \email{houx14@gene.com}
 #'
 #' @examples
-#' library(nestcolor)
-#' ADSL <- osprey::rADSL
-#' ADRS <- osprey::rADRS
-#' ADTR <- osprey::rADTR
+#' data <- cdisc_data() |>
+#'   within(library(nestcolor)) |>
+#'   within({
+#'     ADSL <- rADSL
+#'     ADRS <- rADRS
+#'     ADTR <- rADTR
+#'     ADSL$SEX <- factor(ADSL$SEX, levels = unique(ADSL$SEX))
+#'   })
 #'
-#' ADSL$SEX <- factor(ADSL$SEX, levels = unique(ADSL$SEX))
+#' datanames(data) <- c("ADSL", "ADTR", "ADRS")
+#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
 #'
-#' app <- teal::init(
-#'   data = cdisc_data(
-#'     cdisc_dataset("ADSL", ADSL,
-#'       code = "ADSL <- rADSL
-#'               ADSL$SEX <- factor(ADSL$SEX, levels = unique(ADSL$SEX))"
-#'     ),
-#'     cdisc_dataset("ADRS", ADRS, code = "ADRS <- rADRS"),
-#'     cdisc_dataset("ADTR", ADTR,
-#'       code = " ADTR <- rADTR",
-#'       c("STUDYID", "USUBJID", "PARAMCD", "AVISIT")
-#'     ),
-#'     check = TRUE
-#'   ),
+#' app <- init(
+#'   data = data,
 #'   modules = modules(
 #'     tm_g_waterfall(
 #'       label = "Waterfall",
 #'       dataname_tr = "ADTR",
 #'       dataname_rs = "ADRS",
-#'       bar_paramcd = teal.transform::choices_selected(c("SLDINV"), "SLDINV"),
-#'       bar_var = teal.transform::choices_selected(c("PCHG", "AVAL"), "PCHG"),
-#'       bar_color_var = teal.transform::choices_selected(c("ARMCD", "SEX"), "ARMCD"),
+#'       bar_paramcd = choices_selected(c("SLDINV"), "SLDINV"),
+#'       bar_var = choices_selected(c("PCHG", "AVAL"), "PCHG"),
+#'       bar_color_var = choices_selected(c("ARMCD", "SEX"), "ARMCD"),
 #'       bar_color_opt = NULL,
-#'       sort_var = teal.transform::choices_selected(c("ARMCD", "SEX"), NULL),
-#'       add_label_var_sl = teal.transform::choices_selected(c("SEX", "EOSDY"), NULL),
-#'       add_label_paramcd_rs = teal.transform::choices_selected(c("BESRSPI", "OBJRSPI"), NULL),
-#'       anno_txt_var_sl = teal.transform::choices_selected(c("SEX", "ARMCD", "BMK1", "BMK2"), NULL),
-#'       anno_txt_paramcd_rs = teal.transform::choices_selected(c("BESRSPI", "OBJRSPI"), NULL),
-#'       facet_var = teal.transform::choices_selected(c("SEX", "ARMCD", "STRATA1", "STRATA2"), NULL),
+#'       sort_var = choices_selected(c("ARMCD", "SEX"), NULL),
+#'       add_label_var_sl = choices_selected(c("SEX", "EOSDY"), NULL),
+#'       add_label_paramcd_rs = choices_selected(c("BESRSPI", "OBJRSPI"), NULL),
+#'       anno_txt_var_sl = choices_selected(c("SEX", "ARMCD", "BMK1", "BMK2"), NULL),
+#'       anno_txt_paramcd_rs = choices_selected(c("BESRSPI", "OBJRSPI"), NULL),
+#'       facet_var = choices_selected(c("SEX", "ARMCD", "STRATA1", "STRATA2"), NULL),
 #'       href_line = "-30, 20"
 #'     )
 #'   )
@@ -89,6 +83,7 @@
 #' if (interactive()) {
 #'   shinyApp(app$ui, app$server)
 #' }
+#'
 tm_g_waterfall <- function(label,
                            dataname_tr = "ADTR",
                            dataname_rs = "ADRS",

--- a/man/tm_g_ae_oview.Rd
+++ b/man/tm_g_ae_oview.Rd
@@ -51,77 +51,51 @@ the \code{\link[teal:module]{teal::module()}} object.
 Display the \code{AE} overview plot as a shiny module
 }
 \examples{
-library(nestcolor)
+data <- cdisc_data() |>
+  within(library(nestcolor)) |>
+  within({
+    ADSL <- rADSL
+    ADAE <- rADAE
+    add_event_flags <- function(dat) {
+      dat <- dat |>
+        mutate(
+          TMPFL_SER = AESER == "Y",
+          TMPFL_REL = AEREL == "Y",
+          TMPFL_GR5 = AETOXGR == "5",
+          AEREL1 = (AEREL == "Y" & ACTARM == "A: Drug X"),
+          AEREL2 = (AEREL == "Y" & ACTARM == "B: Placebo")
+        )
+      labels <- c(
+        "Serious AE", "Related AE", "Grade 5 AE",
+        "AE related to A: Drug X", "AE related to B: Placebo"
+      )
+      cols <- c("TMPFL_SER", "TMPFL_REL", "TMPFL_GR5", "AEREL1", "AEREL2")
+      for (i in seq_along(labels)) {
+        attr(dat[[cols[i]]], "label") <- labels[i]
+      }
+      dat
+    }
+    ADAE <- add_event_flags(ADAE)
+  })
 
-ADSL <- osprey::rADSL
-ADAE <- osprey::rADAE
+datanames(data) <- c("ADSL", "ADAE")
+join_keys(data) <- default_cdisc_join_keys[datanames(data)]
 
-# Add additional dummy causality flags.
-add_event_flags <- function(dat) {
-  dat <- dat \%>\%
-    dplyr::mutate(
-      TMPFL_SER = AESER == "Y",
-      TMPFL_REL = AEREL == "Y",
-      TMPFL_GR5 = AETOXGR == "5",
-      AEREL1 = (AEREL == "Y" & ACTARM == "A: Drug X"),
-      AEREL2 = (AEREL == "Y" & ACTARM == "B: Placebo")
-    )
-  labels <- c(
-    "Serious AE", "Related AE", "Grade 5 AE",
-    "AE related to A: Drug X", "AE related to B: Placebo"
-  )
-  cols <- c("TMPFL_SER", "TMPFL_REL", "TMPFL_GR5", "AEREL1", "AEREL2")
-  for (i in seq_along(labels)) {
-    attr(dat[[cols[i]]], "label") <- labels[i]
-  }
-  dat
-}
-ADAE <- ADAE \%>\% add_event_flags()
+ADAE <- data[["ADAE"]]
 
 app <- init(
-  data = cdisc_data(
-    cdisc_dataset("ADSL", ADSL, code = "ADSL <- osprey::rADSL"),
-    cdisc_dataset("ADAE", ADAE,
-      code =
-        "ADAE <- osprey::rADAE
-           add_event_flags <- function(dat) {
-             dat <- dat \%>\%
-               dplyr::mutate(
-                 TMPFL_SER = AESER == 'Y',
-                 TMPFL_REL = AEREL == 'Y',
-                 TMPFL_GR5 = AETOXGR == '5',
-                 AEREL1 = (AEREL == 'Y' & ACTARM == 'A: Drug X'),
-                 AEREL2 = (AEREL == 'Y' & ACTARM == 'B: Placebo')
-               )
-             labels <- c(
-               'Serious AE',
-               'Related AE',
-               'Grade 5 AE',
-               'AE related to A: Drug X',
-               'AE related to B: Placebo'
-             )
-             cols <- c('TMPFL_SER', 'TMPFL_REL', 'TMPFL_GR5', 'AEREL1', 'AEREL2')
-             for (i in seq_along(labels)) {
-              attr(dat[[cols[i]]], 'label') <- labels[i]
-             }
-             dat
-           }
-           # Generating user-defined event flags.
-           ADAE <- ADAE \%>\% add_event_flags()"
-    ),
-    check = TRUE
-  ),
+  data = data,
   modules = modules(
     tm_g_ae_oview(
       label = "AE Overview",
       dataname = "ADAE",
-      arm_var = teal.transform::choices_selected(
+      arm_var = choices_selected(
         selected = "ACTARM",
         choices = c("ACTARM", "ACTARMCD")
       ),
-      flag_var_anl = teal.transform::choices_selected(
+      flag_var_anl = choices_selected(
         selected = "AEREL1",
-        choices = teal.transform::variable_choices(
+        choices = variable_choices(
           ADAE,
           c("TMPFL_SER", "TMPFL_REL", "TMPFL_GR5", "AEREL1", "AEREL2")
         ),
@@ -133,4 +107,5 @@ app <- init(
 if (interactive()) {
   shinyApp(app$ui, app$server)
 }
+
 }

--- a/man/tm_g_ae_sub.Rd
+++ b/man/tm_g_ae_sub.Rd
@@ -49,16 +49,17 @@ the \code{\link[teal:module]{teal::module()}} object.
 Display the \code{AE} by subgroups plot as a teal module
 }
 \examples{
-# Example using stream (ADaM) dataset
-ADSL <- osprey::rADSL
-ADAE <- osprey::rADAE
+data <- cdisc_data() |>
+  within({
+    ADSL <- rADSL
+    ADAE <- rADAE
+  })
+
+datanames(data) <- c("ADSL", "ADAE")
+join_keys(data) <- default_cdisc_join_keys[datanames(data)]
 
 app <- init(
-  data = cdisc_data(
-    cdisc_dataset("ADSL", ADSL, code = "ADSL <- osprey::rADSL"),
-    cdisc_dataset("ADAE", ADAE, code = "ADAE <- osprey::rADAE"),
-    check = TRUE
-  ),
+  data = data,
   modules = modules(
     tm_g_ae_sub(
       label = "AE by Subgroup",
@@ -78,6 +79,7 @@ app <- init(
 if (interactive()) {
   shinyApp(app$ui, app$server)
 }
+
 }
 \author{
 Liming Li (Lil128) \email{liming.li@roche.com}

--- a/man/tm_g_butterfly.Rd
+++ b/man/tm_g_butterfly.Rd
@@ -86,69 +86,59 @@ used for subsequent analysis. Flag variables (from \code{ADaM} datasets) can be
 used directly as filter.
 }
 \examples{
+data <- cdisc_data() |>
+  within({
+    library(dplyr)
+    library(nestcolor)
+  }) |>
+  within({
+    set.seed(23)
+    ADSL <- rADSL
+    ADAE <- rADAE
+    ADSL <- mutate(ADSL, DOSE = paste(sample(1:3, n(), replace = TRUE), "UG"))
+    ADAE <- mutate(
+      ADAE,
+      flag1 = ifelse(AETOXGR == 1, 1, 0),
+      flag2 = ifelse(AETOXGR == 2, 1, 0),
+      flag3 = ifelse(AETOXGR == 3, 1, 0),
+      flag1_filt = rep("Y", n())
+    )
+  })
 
-# Example using stream (ADaM) dataset
-library(dplyr)
-library(nestcolor)
-
-set.seed(23)
-ADSL <- osprey::rADSL
-ADAE <- osprey::rADAE
-ADSL <- mutate(ADSL, DOSE = paste(sample(1:3, n(), replace = TRUE), "UG"))
-ADAE <- mutate(
-  ADAE,
-  flag1 = ifelse(AETOXGR == 1, 1, 0),
-  flag2 = ifelse(AETOXGR == 2, 1, 0),
-  flag3 = ifelse(AETOXGR == 3, 1, 0),
-  flag1_filt = rep("Y", n())
-)
+datanames(data) <- c("ADSL", "ADAE")
+join_keys(data) <- default_cdisc_join_keys[datanames(data)]
 
 app <- init(
-  data = cdisc_data(
-    cdisc_dataset("ADSL", ADSL,
-      code = "ADSL <- osprey::rADSL
-              set.seed(23)
-              ADSL <- mutate(ADSL, DOSE = paste(sample(1:3, n(), replace = TRUE), 'UG'))"
-    ),
-    cdisc_dataset("ADAE", ADAE,
-      code = "ADAE <- osprey::rADAE
-              ADAE <- mutate(ADAE,
-              flag1 = ifelse(AETOXGR == 1, 1, 0),
-              flag2 = ifelse(AETOXGR == 2, 1, 0),
-              flag3 = ifelse(AETOXGR == 3, 1, 0),
-              flag1_filt = rep('Y', n()))"
-    ),
-    check = TRUE
-  ),
+  data = data,
   modules = modules(
     tm_g_butterfly(
       label = "Butterfly Plot",
       dataname = "ADAE",
-      right_var = teal.transform::choices_selected(
+      right_var = choices_selected(
         selected = "SEX",
         choices = c("SEX", "ARM", "RACE")
       ),
-      left_var = teal.transform::choices_selected(
+      left_var = choices_selected(
         selected = "RACE",
         choices = c("SEX", "ARM", "RACE")
       ),
-      category_var = teal.transform::choices_selected(
+      category_var = choices_selected(
         selected = "AEBODSYS",
         choices = c("AEDECOD", "AEBODSYS")
       ),
-      color_by_var = teal.transform::choices_selected(
+      color_by_var = choices_selected(
         selected = "AETOXGR",
         choices = c("AETOXGR", "None")
       ),
-      count_by_var = teal.transform::choices_selected(
+      count_by_var = choices_selected(
         selected = "# of patients",
         choices = c("# of patients", "# of AEs")
       ),
-      facet_var = teal.transform::choices_selected(
+      facet_var = choices_selected(
         selected = NULL,
         choices = c("RACE", "SEX", "ARM")
       ),
-      sort_by_var = teal.transform::choices_selected(
+      sort_by_var = choices_selected(
         selected = "count",
         choices = c("count", "alphabetical")
       ),

--- a/man/tm_g_events_term_id.Rd
+++ b/man/tm_g_events_term_id.Rd
@@ -50,29 +50,30 @@ the \code{\link[teal:module]{teal::module()}} object.
 Display Events by Term plot as a shiny module
 }
 \examples{
-library(nestcolor)
+data <- cdisc_data() |>
+  within(library(nestcolor)) |>
+  within({
+    ADSL <- rADSL
+    ADAE <- rADAE
+  })
 
-ADSL <- osprey::rADSL
-ADAE <- osprey::rADAE
+datanames(data) <- c("ADSL", "ADAE")
+join_keys(data) <- default_cdisc_join_keys[datanames(data)]
 
 app <- init(
-  data = cdisc_data(
-    cdisc_dataset("ADSL", ADSL, code = "ADSL <- osprey::rADSL"),
-    cdisc_dataset("ADAE", ADAE, code = "ADAE <- osprey::rADAE"),
-    check = TRUE
-  ),
+  data = data,
   modules = modules(
     tm_g_events_term_id(
       label = "Common AE",
       dataname = "ADAE",
-      term_var = teal.transform::choices_selected(
+      term_var = choices_selected(
         selected = "AEDECOD",
         choices = c(
           "AEDECOD", "AETERM",
           "AEHLT", "AELLT", "AEBODSYS"
         )
       ),
-      arm_var = teal.transform::choices_selected(
+      arm_var = choices_selected(
         selected = "ACTARMCD",
         choices = c("ACTARM", "ACTARMCD")
       ),

--- a/man/tm_g_heat_bygrade.Rd
+++ b/man/tm_g_heat_bygrade.Rd
@@ -76,61 +76,22 @@ the \code{\link[teal:module]{teal::module()}} object.
 Display the heatmap by grade as a shiny module
 }
 \examples{
-library(dplyr)
-library(nestcolor)
-ADSL <- osprey::rADSL \%>\% slice(1:30)
-ADEX <- osprey::rADEX \%>\% filter(USUBJID \%in\% ADSL$USUBJID)
-ADAE <- osprey::rADAE \%>\% filter(USUBJID \%in\% ADSL$USUBJID)
-ADCM <- osprey::rADCM \%>\% filter(USUBJID \%in\% ADSL$USUBJID)
-
-# This preprocess is only to force legacy standard on ADCM
-ADCM <- ADCM \%>\%
-  select(-starts_with("ATC")) \%>\%
-  unique()
-
-# function to derive AVISIT from ADEX
-add_visit <- function(data_need_visit) {
-  visit_dates <- ADEX \%>\%
-    filter(PARAMCD == "DOSE") \%>\%
-    distinct(USUBJID, AVISIT, ASTDTM) \%>\%
-    group_by(USUBJID) \%>\%
-    arrange(ASTDTM) \%>\%
-    mutate(next_vis = lead(ASTDTM), is_last = ifelse(is.na(next_vis), TRUE, FALSE)) \%>\%
-    rename(this_vis = ASTDTM)
-  data_visit <- data_need_visit \%>\%
-    select(USUBJID, ASTDTM) \%>\%
-    left_join(visit_dates, by = "USUBJID") \%>\%
-    filter(ASTDTM > this_vis & (ASTDTM < next_vis | is_last == TRUE)) \%>\%
-    left_join(data_need_visit) \%>\%
-    distinct()
-  return(data_visit)
-}
-# derive AVISIT for ADAE and ADCM
-ADAE <- add_visit(ADAE)
-ADCM <- add_visit(ADCM)
-# derive ongoing status variable for ADEX
-ADEX <- ADEX \%>\%
-  filter(PARCAT1 == "INDIVIDUAL") \%>\%
-  mutate(ongo_status = (EOSSTT == "ONGOING"))
-
-app <- init(
-  data = cdisc_data(
-    cdisc_dataset("ADSL", ADSL),
-    cdisc_dataset("ADEX", ADEX),
-    cdisc_dataset("ADAE", ADAE),
-    cdisc_dataset("ADCM", ADCM, keys = c("STUDYID", "USUBJID", "ASTDTM", "CMSEQ", "CMDECOD")),
-    code = "
-    ADSL <- osprey::rADSL \%>\% slice(1:30)
-    ADEX <- osprey::rADEX \%>\% filter(USUBJID \%in\% ADSL$USUBJID)
-    ADAE <- osprey::rADAE \%>\% filter(USUBJID \%in\% ADSL$USUBJID)
-    ADCM <- osprey::rADCM \%>\% filter(USUBJID \%in\% ADSL$USUBJID)
-    ADCM <- ADCM \%>\% select(-starts_with(\"ATC\")) \%>\% unique()
-    ADEX  <- ADEX \%>\%
-      filter(PARCAT1 == 'INDIVIDUAL') \%>\%
-      mutate(ongo_status = (EOSSTT == 'ONGOING'))
+data <- cdisc_data() |>
+  within({
+    library(dplyr)
+    library(nestcolor)
+    }) |>
+  within({
+    ADSL <- rADSL \%>\% slice(1:30)
+    ADEX <- rADEX \%>\% filter(USUBJID \%in\% ADSL$USUBJID)
+    ADAE <- rADAE \%>\% filter(USUBJID \%in\% ADSL$USUBJID)
+    ADCM <- rADCM \%>\% filter(USUBJID \%in\% ADSL$USUBJID)
+    # This preprocess is only to force legacy standard on ADCM
+    ADCM <- ADCM \%>\% select(-starts_with("ATC")) \%>\% unique()
+    # function to derive AVISIT from ADEX
     add_visit <- function(data_need_visit) {
       visit_dates <- ADEX \%>\%
-        filter(PARAMCD == 'DOSE') \%>\%
+        filter(PARAMCD == "DOSE") \%>\%
         distinct(USUBJID, AVISIT, ASTDTM) \%>\%
         group_by(USUBJID) \%>\%
         arrange(ASTDTM) \%>\%
@@ -138,16 +99,26 @@ app <- init(
         rename(this_vis = ASTDTM)
       data_visit <- data_need_visit \%>\%
         select(USUBJID, ASTDTM) \%>\%
-        left_join(visit_dates, by = 'USUBJID') \%>\%
+        left_join(visit_dates, by = "USUBJID") \%>\%
         filter(ASTDTM > this_vis & (ASTDTM < next_vis | is_last == TRUE)) \%>\%
-        left_join(data_need_visit) \%>\% distinct()
+        left_join(data_need_visit) \%>\%
+        distinct()
       return(data_visit)
     }
+    # derive AVISIT for ADAE and ADCM
     ADAE <- add_visit(ADAE)
     ADCM <- add_visit(ADCM)
-    ",
-    check = TRUE
-  ),
+    # derive ongoing status variable for ADEX
+    ADEX <- ADEX \%>\% filter(PARCAT1 == "INDIVIDUAL") \%>\% mutate(ongo_status = (EOSSTT == "ONGOING"))
+  })
+
+datanames(data) <- c("ADSL", "ADEX", "ADAE", "ADCM")
+join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+
+ADCM <- data[["ADCM"]]
+
+app <- init(
+  data = data,
   modules = modules(
     tm_g_heat_bygrade(
       label = "Heatmap by grade",
@@ -155,27 +126,27 @@ app <- init(
       ex_dataname = "ADEX",
       ae_dataname = "ADAE",
       cm_dataname = "ADCM",
-      id_var = teal.transform::choices_selected(
+      id_var = choices_selected(
         selected = "USUBJID",
         choices = c("USUBJID", "SUBJID")
       ),
-      visit_var = teal.transform::choices_selected(
+      visit_var = choices_selected(
         selected = "AVISIT",
         choices = c("AVISIT")
       ),
-      ongo_var = teal.transform::choices_selected(
+      ongo_var = choices_selected(
         selected = "ongo_status",
         choices = c("ongo_status")
       ),
-      anno_var = teal.transform::choices_selected(
+      anno_var = choices_selected(
         selected = c("SEX", "COUNTRY"),
         choices = c("SEX", "COUNTRY", "USUBJID")
       ),
-      heat_var = teal.transform::choices_selected(
+      heat_var = choices_selected(
         selected = "AETOXGR",
         choices = c("AETOXGR")
       ),
-      conmed_var = teal.transform::choices_selected(
+      conmed_var = choices_selected(
         selected = "CMDECOD",
         choices = c("CMDECOD")
       ),
@@ -186,4 +157,5 @@ app <- init(
 if (interactive()) {
   shinyApp(app$ui, app$server)
 }
+
 }

--- a/man/tm_g_patient_profile.Rd
+++ b/man/tm_g_patient_profile.Rd
@@ -108,70 +108,31 @@ the start date
 }
 }
 \examples{
-library(nestcolor)
+data <- cdisc_data() |>
+  within(library(nestcolor)) |>
+  within({
+    ADSL <- rADSL
+    ADAE <- rADAE \%>\% mutate(ASTDT = as.Date(ASTDTM), AENDT = as.Date(AENDTM))
+    ADCM <- rADCM \%>\% mutate(ASTDT = as.Date(ASTDTM), AENDT = as.Date(AENDTM))
+    # The step below is to pre-process ADCM to legacy standard
+    ADCM <- ADCM \%>\% select(-starts_with("ATC")) \%>\% unique()
+    ADRS <- rADRS \%>\% mutate(ADT = as.Date(ADTM))
+    ADEX <- rADEX \%>\% mutate(ASTDT = as.Date(ASTDTM), AENDT = as.Date(AENDTM))
+    ADLB <- rADLB \%>\% mutate(ADT = as.Date(ADTM), LBSTRESN = as.numeric(LBSTRESC))
 
-ADSL <- osprey::rADSL
-ADAE <- osprey::rADAE \%>\%
-  mutate(
-    ASTDT = as.Date(ASTDTM),
-    AENDT = as.Date(AENDTM)
-  )
-ADCM <- osprey::rADCM \%>\%
-  mutate(
-    ASTDT = as.Date(ASTDTM),
-    AENDT = as.Date(AENDTM)
-  )
+  })
 
-# The step below is to pre-process ADCM to legacy standard
-ADCM <- ADCM \%>\%
-  select(-starts_with("ATC")) \%>\%
-  unique()
+datanames(data) <- c("ADSL", "ADAE", "ADCM", "ADRS", "ADEX", "ADLB")
+join_keys(data) <- default_cdisc_join_keys[datanames(data)]
 
-ADRS <- osprey::rADRS \%>\%
-  mutate(ADT = as.Date(ADTM))
-ADEX <- osprey::rADEX \%>\%
-  mutate(
-    ASTDT = as.Date(ASTDTM),
-    AENDT = as.Date(AENDTM)
-  )
-ADLB <- osprey::rADLB \%>\%
-  mutate(
-    ADT = as.Date(ADTM),
-    LBSTRESN = as.numeric(LBSTRESC)
-  )
+ADSL <- data[["ADSL"]]
 
 app <- init(
-  data = cdisc_data(
-    cdisc_dataset("ADSL", ADSL, code = "ADSL <- osprey::rADSL"),
-    cdisc_dataset("ADRS", ADRS, code = "ADRS <- osprey::rADRS \%>\% mutate(ADT = as.Date(ADTM))"),
-    cdisc_dataset("ADAE", ADAE,
-      code = "ADAE <- osprey::rADAE \%>\%
-              mutate(ASTDT = as.Date(ASTDTM),
-                     AENDT = as.Date(AENDTM))"
-    ),
-    cdisc_dataset("ADCM", ADCM,
-      code = "ADCM <- osprey::rADCM \%>\%
-              mutate(ASTDT = as.Date(ASTDTM),
-                     AENDT = as.Date(AENDTM))
-              ADCM <- ADCM \%>\% select(-starts_with(\"ATC\")) \%>\% unique()",
-      keys = c("STUDYID", "USUBJID", "ASTDTM", "CMSEQ", "CMDECOD")
-    ),
-    cdisc_dataset("ADLB", ADLB,
-      code = "ADLB <- osprey::rADLB \%>\%
-              mutate(ADT = as.Date(ADTM),
-                     LBSTRESN = as.numeric(LBSTRESC))"
-    ),
-    cdisc_dataset("ADEX", ADEX,
-      code = "ADEX <- osprey::rADEX \%>\%
-              mutate(ASTDT = as.Date(ASTDTM),
-                     AENDT = as.Date(AENDTM))"
-    ),
-    check = FALSE # set FALSE here to keep run time of example short, should be set to TRUE
-  ),
+  data = data,
   modules = modules(
     tm_g_patient_profile(
       label = "Patient Profile Plot",
-      patient_id = teal.transform::choices_selected(
+      patient_id = choices_selected(
         choices = unique(ADSL$USUBJID),
         selected = unique(ADSL$USUBJID)[1]
       ),
@@ -181,32 +142,32 @@ app <- init(
       rs_dataname = "ADRS",
       cm_dataname = "ADCM",
       lb_dataname = "ADLB",
-      sl_start_date = teal.transform::choices_selected(
+      sl_start_date = choices_selected(
         selected = "TRTSDTM",
         choices = c("TRTSDTM", "RANDDT")
       ),
-      ex_var = teal.transform::choices_selected(
+      ex_var = choices_selected(
         selected = "PARCAT2",
         choices = "PARCAT2"
       ),
-      ae_var = teal.transform::choices_selected(
+      ae_var = choices_selected(
         selected = "AEDECOD",
         choices = c("AEDECOD", "AESOC")
       ),
-      ae_line_col_var = teal.transform::choices_selected(
+      ae_line_col_var = choices_selected(
         selected = "AESER",
         choices = c("AESER", "AEREL")
       ),
       ae_line_col_opt = c("Y" = "red", "N" = "blue"),
-      rs_var = teal.transform::choices_selected(
+      rs_var = choices_selected(
         selected = "PARAMCD",
         choices = "PARAMCD"
       ),
-      cm_var = teal.transform::choices_selected(
+      cm_var = choices_selected(
         selected = "CMDECOD",
         choices = c("CMDECOD", "CMCAT")
       ),
-      lb_var = teal.transform::choices_selected(
+      lb_var = choices_selected(
         selected = "LBTESTCD",
         choices = c("LBTESTCD", "LBCAT")
       ),

--- a/man/tm_g_spiderplot.Rd
+++ b/man/tm_g_spiderplot.Rd
@@ -77,52 +77,51 @@ the \code{\link[teal:module]{teal::module()}} object.
 Display spider plot as a shiny module
 }
 \examples{
-
 # Example using stream (ADaM) dataset
-library(dplyr)
-library(nestcolor)
+data <- cdisc_data() |>
+  within({
+    library(dplyr)
+    library(nestcolor)
+  }) |>
+  within({
+    ADSL <- rADSL
+    ADTR <- rADTR
+  })
 
-ADSL <- osprey::rADSL
-ADTR <- osprey::rADTR
+datanames(data) <- c("ADSL", "ADTR")
+join_keys(data) <- default_cdisc_join_keys[datanames(data)]
 
-app <- teal::init(
-  data = cdisc_data(
-    cdisc_dataset("ADSL", ADSL, code = "ADSL <- osprey::rADSL"),
-    cdisc_dataset("ADTR", ADTR,
-      code = "ADTR <- osprey::rADTR",
-      keys = c("STUDYID", "USUBJID", "PARAMCD", "AVISIT")
-    ),
-    check = TRUE
-  ),
+app <- init(
+  data = data,
   modules = modules(
     tm_g_spiderplot(
       label = "Spider plot",
       dataname = "ADTR",
-      paramcd = teal.transform::choices_selected(
+      paramcd = choices_selected(
         choices = "SLDINV",
         selected = "SLDINV"
       ),
-      x_var = teal.transform::choices_selected(
+      x_var = choices_selected(
         choices = "ADY",
         selected = "ADY"
       ),
-      y_var = teal.transform::choices_selected(
+      y_var = choices_selected(
         choices = c("PCHG", "CHG", "AVAL"),
         selected = "PCHG"
       ),
-      marker_var = teal.transform::choices_selected(
+      marker_var = choices_selected(
         choices = c("SEX", "RACE", "USUBJID"),
         selected = "SEX"
       ),
-      line_colorby_var = teal.transform::choices_selected(
+      line_colorby_var = choices_selected(
         choices = c("SEX", "USUBJID", "RACE"),
         selected = "SEX"
       ),
-      xfacet_var = teal.transform::choices_selected(
+      xfacet_var = choices_selected(
         choices = c("SEX", "ARM"),
         selected = "SEX"
       ),
-      yfacet_var = teal.transform::choices_selected(
+      yfacet_var = choices_selected(
         choices = c("SEX", "ARM"),
         selected = "ARM"
       ),

--- a/man/tm_g_swimlane.Rd
+++ b/man/tm_g_swimlane.Rd
@@ -81,37 +81,29 @@ the \code{\link[teal:module]{teal::module()}} object.
 This is teal module that generates a \code{swimlane} plot (bar plot with markers) for \code{ADaM} data
 }
 \examples{
-
 # Example using stream (ADaM) dataset
-library(dplyr)
-library(nestcolor)
+data <- teal.data::cdisc_data() |>
+  within(library(dplyr)) |>
+  within(library(nestcolor)) |>
+  within(ADSL <- osprey::rADSL \%>\%
+    dplyr::mutate(TRTDURD = as.integer(TRTEDTM - TRTSDTM) + 1) \%>\%
+    dplyr::filter(STRATA1 == "A" & ARMCD == "ARM A")) |>
+  within(ADRS <- osprey::rADRS) |>
+  within(ADRS <- ADRS \%>\%
+    dplyr::filter(PARAMCD == "LSTASDI" & DCSREAS == "Death") \%>\%
+    mutate(AVALC = DCSREAS, ADY = EOSDY) \%>\%
+    base::rbind(ADRS \%>\% dplyr::filter(PARAMCD == "OVRINV" & AVALC != "NE")) \%>\%
+    arrange(USUBJID))
 
-ADSL <- osprey::rADSL \%>\%
-  dplyr::mutate(TRTDURD = as.integer(TRTEDTM - TRTSDTM) + 1) \%>\%
-  dplyr::filter(STRATA1 == "A" & ARMCD == "ARM A")
-ADRS <- osprey::rADRS
+teal.data::datanames(data) <- c("ADSL", "ADRS")
+teal.data::join_keys(data) <- teal.data::default_cdisc_join_keys[teal.data::datanames(data)]
 
-ADRS <- ADRS \%>\%
-  dplyr::filter(PARAMCD == "LSTASDI" & DCSREAS == "Death") \%>\%
-  mutate(AVALC = DCSREAS, ADY = EOSDY) \%>\%
-  base::rbind(ADRS \%>\% dplyr::filter(PARAMCD == "OVRINV" & AVALC != "NE")) \%>\%
-  arrange(USUBJID)
+ADSL <- data[["ADSL"]]
+ADRS <- data[["ADRS"]]
 
-app <- init(
-  data = cdisc_data(
-    cdisc_dataset("ADSL", ADSL, code = "ADSL <- osprey::rADSL \%>\%
-      dplyr::mutate(TRTDURD = as.integer(TRTEDTM - TRTSDTM) + 1) \%>\%
-      dplyr::filter(STRATA1 == 'A' & ARMCD == 'ARM A')"),
-    cdisc_dataset("ADRS", ADRS,
-      code = "ADRS <- rADRS
-              ADRS <- ADRS \%>\% dplyr::filter(PARAMCD == 'LSTASDI' & DCSREAS == 'Death') \%>\%
-                      mutate(AVALC = DCSREAS, ADY = EOSDY) \%>\%
-              rbind(ADRS \%>\% dplyr::filter(PARAMCD == 'OVRINV' & AVALC != 'NE')) \%>\%
-              arrange(USUBJID)"
-    ),
-    check = TRUE
-  ),
-  modules = modules(
+app <- teal::init(
+  data = data,
+  modules = teal::modules(
     tm_g_swimlane(
       label = "Swimlane Plot",
       dataname = "ADRS",

--- a/man/tm_g_waterfall.Rd
+++ b/man/tm_g_waterfall.Rd
@@ -100,41 +100,35 @@ the \code{\link[teal:module]{teal::module()}} object.
 This is teal module that generates a waterfall plot for \code{ADaM} data
 }
 \examples{
-library(nestcolor)
-ADSL <- osprey::rADSL
-ADRS <- osprey::rADRS
-ADTR <- osprey::rADTR
+data <- cdisc_data() |>
+  within(library(nestcolor)) |>
+  within({
+    ADSL <- rADSL
+    ADRS <- rADRS
+    ADTR <- rADTR
+    ADSL$SEX <- factor(ADSL$SEX, levels = unique(ADSL$SEX))
+  })
 
-ADSL$SEX <- factor(ADSL$SEX, levels = unique(ADSL$SEX))
+datanames(data) <- c("ADSL", "ADTR", "ADRS")
+join_keys(data) <- default_cdisc_join_keys[datanames(data)]
 
-app <- teal::init(
-  data = cdisc_data(
-    cdisc_dataset("ADSL", ADSL,
-      code = "ADSL <- rADSL
-              ADSL$SEX <- factor(ADSL$SEX, levels = unique(ADSL$SEX))"
-    ),
-    cdisc_dataset("ADRS", ADRS, code = "ADRS <- rADRS"),
-    cdisc_dataset("ADTR", ADTR,
-      code = " ADTR <- rADTR",
-      c("STUDYID", "USUBJID", "PARAMCD", "AVISIT")
-    ),
-    check = TRUE
-  ),
+app <- init(
+  data = data,
   modules = modules(
     tm_g_waterfall(
       label = "Waterfall",
       dataname_tr = "ADTR",
       dataname_rs = "ADRS",
-      bar_paramcd = teal.transform::choices_selected(c("SLDINV"), "SLDINV"),
-      bar_var = teal.transform::choices_selected(c("PCHG", "AVAL"), "PCHG"),
-      bar_color_var = teal.transform::choices_selected(c("ARMCD", "SEX"), "ARMCD"),
+      bar_paramcd = choices_selected(c("SLDINV"), "SLDINV"),
+      bar_var = choices_selected(c("PCHG", "AVAL"), "PCHG"),
+      bar_color_var = choices_selected(c("ARMCD", "SEX"), "ARMCD"),
       bar_color_opt = NULL,
-      sort_var = teal.transform::choices_selected(c("ARMCD", "SEX"), NULL),
-      add_label_var_sl = teal.transform::choices_selected(c("SEX", "EOSDY"), NULL),
-      add_label_paramcd_rs = teal.transform::choices_selected(c("BESRSPI", "OBJRSPI"), NULL),
-      anno_txt_var_sl = teal.transform::choices_selected(c("SEX", "ARMCD", "BMK1", "BMK2"), NULL),
-      anno_txt_paramcd_rs = teal.transform::choices_selected(c("BESRSPI", "OBJRSPI"), NULL),
-      facet_var = teal.transform::choices_selected(c("SEX", "ARMCD", "STRATA1", "STRATA2"), NULL),
+      sort_var = choices_selected(c("ARMCD", "SEX"), NULL),
+      add_label_var_sl = choices_selected(c("SEX", "EOSDY"), NULL),
+      add_label_paramcd_rs = choices_selected(c("BESRSPI", "OBJRSPI"), NULL),
+      anno_txt_var_sl = choices_selected(c("SEX", "ARMCD", "BMK1", "BMK2"), NULL),
+      anno_txt_paramcd_rs = choices_selected(c("BESRSPI", "OBJRSPI"), NULL),
+      facet_var = choices_selected(c("SEX", "ARMCD", "STRATA1", "STRATA2"), NULL),
       href_line = "-30, 20"
     )
   )
@@ -142,6 +136,7 @@ app <- teal::init(
 if (interactive()) {
   shinyApp(app$ui, app$server)
 }
+
 }
 \author{
 Ting Qi (qit3) \email{qit3@gene.com}


### PR DESCRIPTION
Closes #231 

Modified example apps to use the following pattern:
1. create `cdisc_data`
2. use within to evaluate code one line at a time
3. set datanames manually (enumerate datasets)
4. set join keys automatically with `default_cdisc_join_keys[datanames(data)]`
5. assign datasets in global
6. create app
7. run app

Added package prefixes to all `teal*` package functions.