### PR TITLE
`tdata` to `teal_data` - `tm_g_spiderplot`

### DIFF
--- a/R/tm_g_spiderplot.R
+++ b/R/tm_g_spiderplot.R
@@ -244,8 +244,8 @@ srv_g_spider <- function(id, data, filter_panel_api, reporter, dataname, label, 
 
   moduleServer(id, function(input, output, session) {
     iv <- reactive({
-      ADSL <- data[["ADSL"]]() # nolint
-      ADTR <- data[[dataname]]() # nolint
+      ADSL <- data()[["ADSL"]] # nolint
+      ADTR <- data()[[dataname]] # nolint
 
       iv <- shinyvalidate::InputValidator$new()
       iv$add_rule("paramcd", shinyvalidate::sv_required(
@@ -284,8 +284,8 @@ srv_g_spider <- function(id, data, filter_panel_api, reporter, dataname, label, 
     # render plot
     output_q <- reactive({
       # get datasets ---
-      ADSL <- data[["ADSL"]]() # nolint
-      ADTR <- data[[dataname]]() # nolint
+      ADSL <- data()[["ADSL"]] # nolint
+      ADTR <- data()[[dataname]] # nolint
 
       teal::validate_inputs(iv())
 
@@ -325,7 +325,7 @@ srv_g_spider <- function(id, data, filter_panel_api, reporter, dataname, label, 
 
       # merge
       q1 <- teal.code::eval_code(
-        teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)),
+        data(),
         code = bquote({
           ADSL <- ADSL[, .(adsl_vars)] %>% as.data.frame() # nolint
           ADTR <- .(as.name(dataname))[, .(adtr_vars)] %>% as.data.frame() # nolint

--- a/R/tm_g_spiderplot.R
+++ b/R/tm_g_spiderplot.R
@@ -240,7 +240,8 @@ ui_g_spider <- function(id, ...) {
 srv_g_spider <- function(id, data, filter_panel_api, reporter, dataname, label, plot_height, plot_width) {
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
-  checkmate::assert_class(data, "tdata")
+  checkmate::assert_class(data, "reactive")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
     iv <- reactive({


### PR DESCRIPTION
**Example App**

```r
data <- cdisc_data() |>
  within({
    library(nestcolor)
    ADSL <- rADSL
    ADTR <- rADTR
  })

datanames(data) <- c("ADSL", "ADTR")
join_keys(data) <- default_cdisc_join_keys[datanames(data)]

app <- init(
  data = data,
  modules = modules(
    tm_g_spiderplot(
      label = "Spider plot",
      dataname = "ADTR",
      paramcd = choices_selected(
        choices = "SLDINV",
        selected = "SLDINV"
      ),
      x_var = choices_selected(
        choices = "ADY",
        selected = "ADY"
      ),
      y_var = choices_selected(
        choices = c("PCHG", "CHG", "AVAL"),
        selected = "PCHG"
      ),
      marker_var = choices_selected(
        choices = c("SEX", "RACE", "USUBJID"),
        selected = "SEX"
      ),
      line_colorby_var = choices_selected(
        choices = c("SEX", "USUBJID", "RACE"),
        selected = "SEX"
      ),
      xfacet_var = choices_selected(
        choices = c("SEX", "ARM"),
        selected = "SEX"
      ),
      yfacet_var = choices_selected(
        choices = c("SEX", "ARM"),
        selected = "ARM"
      ),
      vref_line = "10, 37",
      href_line = "-20, 0"
    )
  )
)
if (interactive()) {
  shinyApp(app$ui, app$server)
}
```