### PR TITLE
`tdata` to `teal_data` - `tm_g_waterfall`

### DIFF
--- a/R/tm_g_waterfall.R
+++ b/R/tm_g_waterfall.R
@@ -288,9 +288,9 @@ srv_g_waterfall <- function(id,
 
   moduleServer(id, function(input, output, session) {
     iv <- reactive({
-      adsl <- data[["ADSL"]]()
-      adtr <- data[[dataname_tr]]()
-      adrs <- data[[dataname_rs]]()
+      adsl <- data()[["ADSL"]]
+      adtr <- data()[[dataname_tr]]
+      adrs <- data()[[dataname_rs]]
 
       iv <- shinyvalidate::InputValidator$new()
       iv$add_rule("bar_var", shinyvalidate::sv_required(
@@ -339,9 +339,9 @@ srv_g_waterfall <- function(id,
     })
 
     output_q <- reactive({
-      adsl <- data[["ADSL"]]()
-      adtr <- data[[dataname_tr]]()
-      adrs <- data[[dataname_rs]]()
+      adsl <- data()[["ADSL"]]
+      adtr <- data()[[dataname_tr]]
+      adrs <- data()[[dataname_rs]]
 
       # validate data rows
       teal::validate_has_data(adsl, min_nrow = 2)
@@ -405,7 +405,7 @@ srv_g_waterfall <- function(id,
 
       # write variables to qenv
       q1 <- teal.code::eval_code(
-        teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)),
+        data(),
         code = bquote({
           bar_var <- .(bar_var)
           bar_color_var <- .(bar_color_var)

--- a/R/tm_g_waterfall.R
+++ b/R/tm_g_waterfall.R
@@ -284,7 +284,8 @@ srv_g_waterfall <- function(id,
                             plot_width) {
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
-  checkmate::assert_class(data, "tdata")
+  checkmate::assert_class(data, "reactive")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
     iv <- reactive({


### PR DESCRIPTION
**Example App**

```r
data <- cdisc_data() |>
  within({
    library(nestcolor)
    ADSL <- rADSL
    ADRS <- rADRS
    ADTR <- rADTR
    ADSL$SEX <- factor(ADSL$SEX, levels = unique(ADSL$SEX))
  })

datanames(data) <- c("ADSL", "ADTR", "ADRS")
join_keys(data) <- default_cdisc_join_keys[datanames(data)]

app <- init(
  data = data,
  modules = modules(
    tm_g_waterfall(
      label = "Waterfall",
      dataname_tr = "ADTR",
      dataname_rs = "ADRS",
      bar_paramcd = choices_selected(c("SLDINV"), "SLDINV"),
      bar_var = choices_selected(c("PCHG", "AVAL"), "PCHG"),
      bar_color_var = choices_selected(c("ARMCD", "SEX"), "ARMCD"),
      bar_color_opt = NULL,
      sort_var = choices_selected(c("ARMCD", "SEX"), NULL),
      add_label_var_sl = choices_selected(c("SEX", "EOSDY"), NULL),
      add_label_paramcd_rs = choices_selected(c("BESRSPI", "OBJRSPI"), NULL),
      anno_txt_var_sl = choices_selected(c("SEX", "ARMCD", "BMK1", "BMK2"), NULL),
      anno_txt_paramcd_rs = choices_selected(c("BESRSPI", "OBJRSPI"), NULL),
      facet_var = choices_selected(c("SEX", "ARMCD", "STRATA1", "STRATA2"), NULL),
      href_line = "-30, 20"
    )
  )
)
if (interactive()) {
  shinyApp(app$ui, app$server)
}
```