### PR TITLE
898 save app state version 3

### DIFF
--- a/R/tm_g_ae_oview.R
+++ b/R/tm_g_ae_oview.R
@@ -247,12 +247,15 @@ srv_g_ae_oview <- function(id,
       req(!is.null(input$diff_ci_method) && !is.null(input$conf_level))
       diff_ci_method <- input$diff_ci_method
       conf_level <- input$conf_level
-      updateTextAreaInput(session,
-        "foot",
-        value = sprintf(
-          "Note: %d%% CI is calculated using %s",
-          round(conf_level * 100),
-          name_ci(diff_ci_method)
+      updateTextAreaInput(
+        inputId = "foot",
+        value = restoreInput(
+          ns(foot),
+          sprintf(
+            "Note: %d%% CI is calculated using %s",
+            round(conf_level * 100),
+            name_ci(diff_ci_method)
+          )
         )
       )
     })
@@ -270,15 +273,13 @@ srv_g_ae_oview <- function(id,
       }
 
       updateSelectInput(
-        session,
-        "arm_ref",
-        selected = choices[1],
-        choices = choices
+        inputId = "arm_ref",
+        choices = choices,
+        selected = restoreInput(ns("arm_ref", choices[1L]))
       )
       updateSelectInput(
-        session,
-        "arm_trt",
-        selected = choices[trt_index],
+        inputId = "arm_trt",
+        selected = restoreInput(ns("arm_trt", choices[trt_index])),
         choices = choices
       )
     })

--- a/R/tm_g_ae_oview.R
+++ b/R/tm_g_ae_oview.R
@@ -209,6 +209,8 @@ srv_g_ae_oview <- function(id,
   checkmate::assert_class(isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
     iv <- reactive({
       ANL <- data()[[dataname]]
 

--- a/R/tm_g_ae_sub.R
+++ b/R/tm_g_ae_sub.R
@@ -186,6 +186,8 @@ srv_g_ae_sub <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
     iv <- reactive({
       ANL <- data()[[dataname]]
       ADSL <- data()[["ADSL"]]

--- a/R/tm_g_ae_sub.R
+++ b/R/tm_g_ae_sub.R
@@ -239,16 +239,14 @@ srv_g_ae_sub <- function(id,
       }
 
       updateSelectInput(
-        session,
-        "arm_trt",
-        selected = choices[1],
-        choices = choices
+        inputId = "arm_trt",
+        choices = choices,
+        selected = restoreInput(ns("arm_trt", choices[1L]))
       )
       updateSelectInput(
-        session,
-        "arm_ref",
-        selected = choices[ref_index],
-        choices = choices
+        inputId = "arm_ref",
+        choices = choices,
+        selected = restoreInput(ns("arm_ref", choices[ref_index]))
       )
     })
 
@@ -258,14 +256,16 @@ srv_g_ae_sub <- function(id,
       trt <- input$arm_trt
       ref <- input$arm_ref
       updateTextAreaInput(
-        session,
-        "foot",
-        value = sprintf(
-          "Note: %d%% CI is calculated using %s\nTRT: %s; CONT: %s",
-          round(conf_level * 100),
-          name_ci(diff_ci_method),
-          trt,
-          ref
+        inputId = "foot",
+        value = restoreInput(
+          ns("foot"),
+          sprintf(
+            "Note: %d%% CI is calculated using %s\nTRT: %s; CONT: %s",
+            round(conf_level * 100),
+            name_ci(diff_ci_method),
+            trt,
+            ref
+          )
         )
       )
     })
@@ -273,34 +273,32 @@ srv_g_ae_sub <- function(id,
     observeEvent(input$groups, {
       ANL <- data()[[dataname]]
       output$grouplabel_output <- renderUI({
-        grps <- input$groups
+        grps <- req(input$groups)
         lo <- lapply(seq_along(grps), function(index) {
           grp <- grps[index]
           choices <- levels(ANL[[grp]])
           sel <- teal.widgets::optionalSelectInput(
-            session$ns(sprintf("groups__%s", index)),
+            ns(sprintf("groups__%s", index)),
             grp,
             choices,
             multiple = TRUE,
             selected = choices
           )
           textname <- sprintf("text_%s_out", index)
-          txt <- uiOutput(session$ns(textname))
+          txt <- uiOutput(ns(textname))
           observeEvent(
             eventExpr = input[[sprintf("groups__%s", index)]],
             handlerExpr = {
               output[[textname]] <- renderUI({
-                if (!is.null(input[[sprintf("groups__%s", index)]])) {
-                  l <- input[[sprintf("groups__%s", index)]]
-                  l2 <- lapply(seq_along(l), function(i) {
+                grps <- req(input[[sprintf("groups__%s", index)]])
+                if (!is.null(grps)) {
+                  l2 <- lapply(seq_along(grps), function(i) {
                     nm <- sprintf("groups__%s__level__%s", index, i)
-                    label <- sprintf("Label for %s, Level %s", grp, l[i])
-                    textInput(session$ns(nm), label, l[i])
+                    label <- sprintf("Label for %s, Level %s", grp, grps[i])
+                    textInput(ns(nm), label, grps[i])
                   })
                   tagList(textInput(
-                    session$ns(
-                      sprintf("groups__%s__level__%s", index, "all")
-                    ),
+                    ns(sprintf("groups__%s__level__%s", index, "all")),
                     sprintf("Label for %s", grp), grp
                   ), l2)
                 }

--- a/R/tm_g_butterfly.R
+++ b/R/tm_g_butterfly.R
@@ -316,7 +316,7 @@ srv_g_butterfly <- function(id, data, filter_panel_api, reporter, dataname, labe
             session,
             "right_val",
             choices = character(0),
-            selected = character(0)
+            selected = restoreInput(ns("right_val"), character(0))
           )
         } else {
           options$r <- if (right_var %in% names(data()[["ADSL"]])) {
@@ -336,8 +336,10 @@ srv_g_butterfly <- function(id, data, filter_panel_api, reporter, dataname, labe
             options$r[1]
           }
           teal.widgets::updateOptionalSelectInput(
-            session, "right_val",
-            choices = as.character(options$r), selected = selected, label = "Choose Up To 2:"
+            inputId = "right_val",
+            label = "Choose Up To 2:",
+            choices = as.character(options$r),
+            selected = restoreInput(ns("right_val"), selected)
           )
         }
         vars$r <- right_var
@@ -352,8 +354,9 @@ srv_g_butterfly <- function(id, data, filter_panel_api, reporter, dataname, labe
         current_l_var <- isolate(vars$l)
         if (is.null(left_var)) {
           teal.widgets::updateOptionalSelectInput(
-            session, "left_val",
-            choices = character(0), selected = character(0)
+            inputId = "left_val",
+            choices = character(0),
+            selected = restoreInput(ns("left_val"), character(0))
           )
         } else {
           options$l <- if (left_var %in% names(data()[["ADSL"]])) {
@@ -374,8 +377,10 @@ srv_g_butterfly <- function(id, data, filter_panel_api, reporter, dataname, labe
           }
 
           teal.widgets::updateOptionalSelectInput(
-            session, "left_val",
-            choices = as.character(options$l), selected = selected, label = "Choose Up To 2:"
+            inputId = "left_val",
+            label = "Choose Up To 2:",
+            choices = as.character(options$l),
+            selected = restoreInput(ns("left_val"), selected)
           )
         }
         vars$l <- left_var

--- a/R/tm_g_butterfly.R
+++ b/R/tm_g_butterfly.R
@@ -270,6 +270,8 @@ srv_g_butterfly <- function(id, data, filter_panel_api, reporter, dataname, labe
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
     iv <- reactive({
       ADSL <- data()[["ADSL"]]
       ANL <- data()[[dataname]]

--- a/R/tm_g_events_term_id.R
+++ b/R/tm_g_events_term_id.R
@@ -244,12 +244,14 @@ srv_g_events_term_id <- function(id,
       diff_ci_method <- input$diff_ci_method
       conf_level <- input$conf_level
       updateTextAreaInput(
-        session,
-        "foot",
-        value = sprintf(
-          "Note: %d%% CI is calculated using %s",
-          round(conf_level * 100),
-          name_ci(diff_ci_method)
+        inputId = "foot",
+        value = restoreInput(
+          ns("foot"),
+          sprintf(
+            "Note: %d%% CI is calculated using %s",
+            round(conf_level * 100),
+            name_ci(diff_ci_method)
+          )
         )
       )
     })
@@ -259,16 +261,18 @@ srv_g_events_term_id <- function(id,
       {
         sort <- if (is.null(input$sort)) " " else input$sort
         updateTextInput(
-          session,
-          "title",
-          value = sprintf(
-            "Common AE Table %s",
-            c(
-              "term" = "Sorted by Term",
-              "riskdiff" = "Sorted by Risk Difference",
-              "meanrisk" = "Sorted by Mean Risk",
-              " " = ""
-            )[sort]
+          inputId = "title",
+          value = restoreInput(
+            ns("title"),
+            sprintf(
+              "Common AE Table %s",
+              c(
+                "term" = "Sorted by Term",
+                "riskdiff" = "Sorted by Risk Difference",
+                "meanrisk" = "Sorted by Mean Risk",
+                " " = ""
+              )[sort]
+            )
           )
         )
       },
@@ -289,16 +293,14 @@ srv_g_events_term_id <- function(id,
         }
 
         updateSelectInput(
-          session,
-          "arm_ref",
-          selected = choices[1],
-          choices = choices
+          inputId = "arm_ref",
+          choices = choices,
+          selected = restoreInput(ns("arm_ref"), choices[1])
         )
         updateSelectInput(
-          session,
-          "arm_trt",
-          selected = choices[trt_index],
-          choices = choices
+          inputId = "arm_trt",
+          choices = choices,
+          selected = restoreInput(ns("arm_trt"), choices[trt_index])
         )
       },
       ignoreNULL = TRUE

--- a/R/tm_g_events_term_id.R
+++ b/R/tm_g_events_term_id.R
@@ -214,6 +214,8 @@ srv_g_events_term_id <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
     iv <- reactive({
       iv <- shinyvalidate::InputValidator$new()
       iv$add_rule("term", shinyvalidate::sv_required(

--- a/R/tm_g_heat_bygrade.R
+++ b/R/tm_g_heat_bygrade.R
@@ -388,10 +388,9 @@ srv_g_heatmap_bygrade <- function(id,
         choices <- levels(ADCM[[input$conmed_var]])
 
         updateSelectInput(
-          session,
-          "conmed_level",
-          selected = choices[1:3],
-          choices = choices
+          inputId = "conmed_level",
+          choices = choices,
+          selected = restoreInput(ns("conmed_level"), choices[1:3])
         )
       })
     }

--- a/R/tm_g_heat_bygrade.R
+++ b/R/tm_g_heat_bygrade.R
@@ -297,6 +297,8 @@ srv_g_heatmap_bygrade <- function(id,
   if (!is.na(cm_dataname)) checkmate::assert_names(cm_dataname, subset.of = names(data))
 
   moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
     iv <- reactive({
       ADSL <- data()[[sl_dataname]]
       ADEX <- data()[[ex_dataname]]

--- a/R/tm_g_patient_profile.R
+++ b/R/tm_g_patient_profile.R
@@ -377,10 +377,9 @@ srv_g_patient_profile <- function(id,
         choices_selected <- if (length(choices) > 5) choices[1:5] else choices
 
         updateSelectInput(
-          session,
-          "lb_var_show",
-          selected = choices_selected,
-          choices = choices
+          inputId = "lb_var_show",
+          choices = choices,
+          selected = restoreInput(ns("lb_var_show"), choices_selected)
         )
       })
     }

--- a/R/tm_g_patient_profile.R
+++ b/R/tm_g_patient_profile.R
@@ -362,7 +362,10 @@ srv_g_patient_profile <- function(id,
   if (!is.na(lb_dataname)) checkmate::assert_names(lb_dataname, subset.of = names(data))
   if (!is.na(cm_dataname)) checkmate::assert_names(cm_dataname, subset.of = names(data))
   checkboxes <- c(ex_dataname, ae_dataname, rs_dataname, lb_dataname, cm_dataname)
+
   moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
     select_plot <- reactive(
       vapply(checkboxes, function(x) x %in% input$select_ADaM, logical(1L))
     )

--- a/R/tm_g_swimlane.R
+++ b/R/tm_g_swimlane.R
@@ -280,6 +280,8 @@ srv_g_swimlane <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
     iv <- reactive({
       iv <- shinyvalidate::InputValidator$new()
       iv$add_rule("bar_var", shinyvalidate::sv_required(
@@ -298,7 +300,6 @@ srv_g_swimlane <- function(id,
       if (dataname == "ADSL" || is.null(marker_shape_var) || is.null(input$marker_pos_var)) {
         NULL
       } else {
-        ns <- session$ns
         teal.widgets::optionalSelectInput(
           ns("marker_shape_var"), "Marker Shape",
           choices = marker_shape_var$choices,
@@ -311,7 +312,6 @@ srv_g_swimlane <- function(id,
       if (dataname == "ADSL" || is.null(marker_color_var) || is.null(input$marker_pos_var)) {
         NULL
       } else {
-        ns <- session$ns
         teal.widgets::optionalSelectInput(
           ns("marker_color_var"), "Marker Color",
           choices = marker_color_var$choices,


### PR DESCRIPTION
Companion to https://github.com/insightsengineering/teal/pull/1011
Adds `shiny::restoreInput` calls to the `value`/`choices` arguments in `update*Input` calls.