### PR TITLE
Bumps `{rmarkdown}` minimal version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Suggests:
     knitr (>= 1.42),
     logger (>= 0.2.0),
     nestcolor (>= 0.1.0),
-    rmarkdown (>= 2.19),
+    rmarkdown (>= 2.23),
     teal.data (>= 0.3.0.9018),
     testthat (>= 3.1.5),
     withr (>= 2.0.0)


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Necessary bump to overcome a lack of binary on ppm snapshots that causes an error on minimum strategies for `scheduled` workflows.