### PR TITLE
`teal.data::datanames()` is deprecated in favor of dot-prefix and `names()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,8 +24,8 @@ Depends:
     osprey (>= 0.1.16),
     R (>= 3.6),
     shiny (>= 1.6.0),
-    teal (>= 0.14.0.9027),
-    teal.transform (>= 0.4.0.9011)
+    teal (>= 0.15.2.9079),
+    teal.transform (>= 0.5.0.9015)
 Imports:
     checkmate (>= 2.1.0),
     dplyr (>= 1.0.5),
@@ -33,8 +33,8 @@ Imports:
     ggplot2 (>= 3.4.0),
     lifecycle (>= 0.2.0),
     shinyvalidate,
-    teal.code (>= 0.4.1.9009),
-    teal.data (>= 0.3.0.9018),
+    teal.code (>= 0.5.0.9012),
+    teal.data (>= 0.6.0.9015),
     teal.logger (>= 0.2.0.9004),
     teal.reporter (>= 0.2.0),
     teal.widgets (>= 0.4.0),

--- a/R/tm_g_ae_oview.R
+++ b/R/tm_g_ae_oview.R
@@ -20,7 +20,7 @@
 #'   within({
 #'     ADSL <- rADSL
 #'     ADAE <- rADAE
-#'     add_event_flags <- function(dat) {
+#'     .add_event_flags <- function(dat) {
 #'       dat <- dat |>
 #'         mutate(
 #'           TMPFL_SER = AESER == "Y",
@@ -39,11 +39,10 @@
 #'       }
 #'       dat
 #'     }
-#'     ADAE <- add_event_flags(ADAE)
+#'     ADAE <- .add_event_flags(ADAE)
 #'   })
 #'
-#' datanames(data) <- c("ADSL", "ADAE")
-#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #' ADAE <- data[["ADAE"]]
 #'

--- a/R/tm_g_ae_sub.R
+++ b/R/tm_g_ae_sub.R
@@ -24,8 +24,7 @@
 #'     ADAE <- rADAE
 #'   })
 #'
-#' datanames(data) <- c("ADSL", "ADAE")
-#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #' app <- init(
 #'   data = data,

--- a/R/tm_g_butterfly.R
+++ b/R/tm_g_butterfly.R
@@ -57,8 +57,7 @@
 #'     )
 #'   })
 #'
-#' datanames(data) <- c("ADSL", "ADAE")
-#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #' app <- init(
 #'   data = data,

--- a/R/tm_g_events_term_id.R
+++ b/R/tm_g_events_term_id.R
@@ -24,8 +24,7 @@
 #'     ADAE <- rADAE
 #'   })
 #'
-#' datanames(data) <- c("ADSL", "ADAE")
-#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #' app <- init(
 #'   data = data,

--- a/R/tm_g_heat_bygrade.R
+++ b/R/tm_g_heat_bygrade.R
@@ -46,7 +46,7 @@
 #'       select(-starts_with("ATC")) %>%
 #'       unique()
 #'     # function to derive AVISIT from ADEX
-#'     add_visit <- function(data_need_visit) {
+#'     .add_visit <- function(data_need_visit) {
 #'       visit_dates <- ADEX %>%
 #'         filter(PARAMCD == "DOSE") %>%
 #'         distinct(USUBJID, AVISIT, ASTDTM) %>%
@@ -63,16 +63,15 @@
 #'       return(data_visit)
 #'     }
 #'     # derive AVISIT for ADAE and ADCM
-#'     ADAE <- add_visit(ADAE)
-#'     ADCM <- add_visit(ADCM)
+#'     ADAE <- .add_visit(ADAE)
+#'     ADCM <- .add_visit(ADCM)
 #'     # derive ongoing status variable for ADEX
 #'     ADEX <- ADEX %>%
 #'       filter(PARCAT1 == "INDIVIDUAL") %>%
 #'       mutate(ongo_status = (EOSSTT == "ONGOING"))
 #'   })
 #'
-#' datanames(data) <- c("ADSL", "ADEX", "ADAE", "ADCM")
-#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #' ADCM <- data[["ADCM"]]
 #'

--- a/R/tm_g_patient_profile.R
+++ b/R/tm_g_patient_profile.R
@@ -74,8 +74,7 @@
 #'     ADLB <- rADLB %>% mutate(ADT = as.Date(ADTM), LBSTRESN = as.numeric(LBSTRESC))
 #'   })
 #'
-#' datanames(data) <- c("ADSL", "ADAE", "ADCM", "ADRS", "ADEX", "ADLB")
-#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #' ADSL <- data[["ADSL"]]
 #'
@@ -367,7 +366,7 @@ srv_g_patient_profile <- function(id,
       vapply(checkboxes, function(x) x %in% input$select_ADaM, logical(1L))
     )
 
-    resolved <- teal.transform::resolve_delayed(patient_id, as.list(isolate(data())@env))
+    resolved <- teal.transform::resolve_delayed(patient_id, as.list(isolate(data())))
 
     updateSelectizeInput(
       session = session,

--- a/R/tm_g_spiderplot.R
+++ b/R/tm_g_spiderplot.R
@@ -32,8 +32,7 @@
 #'     ADTR <- rADTR
 #'   })
 #'
-#' datanames(data) <- c("ADSL", "ADTR")
-#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #' app <- init(
 #'   data = data,
@@ -247,7 +246,7 @@ srv_g_spider <- function(id, data, filter_panel_api, paramcd, reporter, dataname
   moduleServer(id, function(input, output, session) {
     teal.logger::log_shiny_input_changes(input, namespace = "teal.osprey")
 
-    env <- as.list(isolate(data())@env)
+    env <- as.list(isolate(data()))
     resolved_paramcd <- teal.transform::resolve_delayed(paramcd, env)
 
     teal.widgets::updateOptionalSelectInput(

--- a/R/tm_g_swimlane.R
+++ b/R/tm_g_swimlane.R
@@ -327,8 +327,8 @@ srv_g_swimlane <- function(id,
 
       validate(need("ADSL" %in% names(data()), "'ADSL' not included in data"))
       validate(need(
-        (length(names(data())) == 1 && dataname == "ADSL") ||
-          (length(names(data())) >= 2 && dataname != "ADSL"), paste(
+        (length(data()) == 1 && dataname == "ADSL") ||
+          (length(data()) >= 2 && dataname != "ADSL"), paste(
           "Please either add just 'ADSL' as dataname when just ADSL is available.",
           "In case 2 datasets are available ADSL is not supposed to be the dataname."
         )

--- a/R/tm_g_swimlane.R
+++ b/R/tm_g_swimlane.R
@@ -49,8 +49,7 @@
 #'       arrange(USUBJID)
 #'   })
 #'
-#' datanames(data) <- c("ADSL", "ADRS")
-#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #' ADSL <- data[["ADSL"]]
 #' ADRS <- data[["ADRS"]]
@@ -326,10 +325,10 @@ srv_g_swimlane <- function(id,
     output_q <- reactive({
       teal::validate_inputs(iv())
 
-      validate(need("ADSL" %in% teal.data::datanames(data()), "'ADSL' not included in data"))
+      validate(need("ADSL" %in% names(data()), "'ADSL' not included in data"))
       validate(need(
-        (length(teal.data::datanames(data())) == 1 && dataname == "ADSL") ||
-          (length(teal.data::datanames(data())) >= 2 && dataname != "ADSL"), paste(
+        (length(names(data())) == 1 && dataname == "ADSL") ||
+          (length(names(data())) >= 2 && dataname != "ADSL"), paste(
           "Please either add just 'ADSL' as dataname when just ADSL is available.",
           "In case 2 datasets are available ADSL is not supposed to be the dataname."
         )

--- a/R/tm_g_waterfall.R
+++ b/R/tm_g_waterfall.R
@@ -55,8 +55,7 @@
 #'     ADSL$SEX <- factor(ADSL$SEX, levels = unique(ADSL$SEX))
 #'   })
 #'
-#' datanames(data) <- c("ADSL", "ADTR", "ADRS")
-#' join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #' app <- init(
 #'   data = data,
@@ -287,7 +286,7 @@ srv_g_waterfall <- function(id,
   moduleServer(id, function(input, output, session) {
     teal.logger::log_shiny_input_changes(input, namespace = "teal.osprey")
 
-    env <- as.list(isolate(data())@env)
+    env <- as.list(isolate(data()))
     resolved_bar_paramcd <- teal.transform::resolve_delayed(bar_paramcd, env)
     resolved_add_label_paramcd_rs <- teal.transform::resolve_delayed(add_label_paramcd_rs, env)
     resolved_anno_txt_paramcd_rs <- teal.transform::resolve_delayed(anno_txt_paramcd_rs, env)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,8 @@
 .onLoad <- function(libname, pkgname) {
+  # Fixes R CMD check note on "All declared Imports should be used."
+  # teal.data is necessary to access S3 method names.teal_data
+  teal.data::teal_data
+
   teal.logger::register_logger(namespace = "teal.osprey")
   teal.logger::register_handlers("teal.osprey")
 }

--- a/man/tm_g_ae_oview.Rd
+++ b/man/tm_g_ae_oview.Rd
@@ -55,7 +55,7 @@ data <- teal_data() |>
   within({
     ADSL <- rADSL
     ADAE <- rADAE
-    add_event_flags <- function(dat) {
+    .add_event_flags <- function(dat) {
       dat <- dat |>
         mutate(
           TMPFL_SER = AESER == "Y",
@@ -74,11 +74,10 @@ data <- teal_data() |>
       }
       dat
     }
-    ADAE <- add_event_flags(ADAE)
+    ADAE <- .add_event_flags(ADAE)
   })
 
-datanames(data) <- c("ADSL", "ADAE")
-join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 ADAE <- data[["ADAE"]]
 

--- a/man/tm_g_ae_sub.Rd
+++ b/man/tm_g_ae_sub.Rd
@@ -56,8 +56,7 @@ data <- teal_data() |>
     ADAE <- rADAE
   })
 
-datanames(data) <- c("ADSL", "ADAE")
-join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 app <- init(
   data = data,

--- a/man/tm_g_butterfly.Rd
+++ b/man/tm_g_butterfly.Rd
@@ -103,8 +103,7 @@ data <- teal_data() |>
     )
   })
 
-datanames(data) <- c("ADSL", "ADAE")
-join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 app <- init(
   data = data,

--- a/man/tm_g_events_term_id.Rd
+++ b/man/tm_g_events_term_id.Rd
@@ -56,8 +56,7 @@ data <- teal_data() |>
     ADAE <- rADAE
   })
 
-datanames(data) <- c("ADSL", "ADAE")
-join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 app <- init(
   data = data,

--- a/man/tm_g_heat_bygrade.Rd
+++ b/man/tm_g_heat_bygrade.Rd
@@ -88,7 +88,7 @@ data <- teal_data() |>
       select(-starts_with("ATC")) \%>\%
       unique()
     # function to derive AVISIT from ADEX
-    add_visit <- function(data_need_visit) {
+    .add_visit <- function(data_need_visit) {
       visit_dates <- ADEX \%>\%
         filter(PARAMCD == "DOSE") \%>\%
         distinct(USUBJID, AVISIT, ASTDTM) \%>\%
@@ -105,16 +105,15 @@ data <- teal_data() |>
       return(data_visit)
     }
     # derive AVISIT for ADAE and ADCM
-    ADAE <- add_visit(ADAE)
-    ADCM <- add_visit(ADCM)
+    ADAE <- .add_visit(ADAE)
+    ADCM <- .add_visit(ADCM)
     # derive ongoing status variable for ADEX
     ADEX <- ADEX \%>\%
       filter(PARCAT1 == "INDIVIDUAL") \%>\%
       mutate(ongo_status = (EOSSTT == "ONGOING"))
   })
 
-datanames(data) <- c("ADSL", "ADEX", "ADAE", "ADCM")
-join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 ADCM <- data[["ADCM"]]
 

--- a/man/tm_g_patient_profile.Rd
+++ b/man/tm_g_patient_profile.Rd
@@ -122,8 +122,7 @@ data <- teal_data() |>
     ADLB <- rADLB \%>\% mutate(ADT = as.Date(ADTM), LBSTRESN = as.numeric(LBSTRESC))
   })
 
-datanames(data) <- c("ADSL", "ADAE", "ADCM", "ADRS", "ADEX", "ADLB")
-join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 ADSL <- data[["ADSL"]]
 

--- a/man/tm_g_spiderplot.Rd
+++ b/man/tm_g_spiderplot.Rd
@@ -84,8 +84,7 @@ data <- teal_data() |>
     ADTR <- rADTR
   })
 
-datanames(data) <- c("ADSL", "ADTR")
-join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 app <- init(
   data = data,

--- a/man/tm_g_swimlane.Rd
+++ b/man/tm_g_swimlane.Rd
@@ -95,8 +95,7 @@ data <- teal_data() |>
       arrange(USUBJID)
   })
 
-datanames(data) <- c("ADSL", "ADRS")
-join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 ADSL <- data[["ADSL"]]
 ADRS <- data[["ADRS"]]

--- a/man/tm_g_waterfall.Rd
+++ b/man/tm_g_waterfall.Rd
@@ -108,8 +108,7 @@ data <- teal_data() |>
     ADSL$SEX <- factor(ADSL$SEX, levels = unique(ADSL$SEX))
   })
 
-datanames(data) <- c("ADSL", "ADTR", "ADRS")
-join_keys(data) <- default_cdisc_join_keys[datanames(data)]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 app <- init(
   data = data,


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/teal.data/issues/333

Blocked by:

- https://github.com/insightsengineering/teal.code/pull/218
- https://github.com/insightsengineering/teal.data/pull/347
- https://github.com/insightsengineering/teal/pull/1402