### PR TITLE
Fix documentation note about links on r-devel

### DIFF
--- a/R/teal.osprey.R
+++ b/R/teal.osprey.R
@@ -1,7 +1,7 @@
 #' `teal.osprey`: `teal` modules for 'osprey'
 #'
-#' `teal.osprey` provides community contributed [`teal`] modules of the analysis functions from
-#' [`osprey`] package. See package [website](https://insightsengineering.github.io/osprey/).
+#' `teal.osprey` provides community contributed [`teal`](https://cran.r-project.org/package=teal) modules of
+#' the analysis functions from `osprey` package. See package [website](https://insightsengineering.github.io/osprey/).
 #' This enables `teal` app developers to easily create applications making use of the `osprey` analysis functions.
 #'
 #' @import dplyr osprey shiny teal formatters teal.transform

--- a/man/teal.osprey-package.Rd
+++ b/man/teal.osprey-package.Rd
@@ -6,8 +6,8 @@
 \alias{teal.osprey-package}
 \title{\code{teal.osprey}: \code{teal} modules for 'osprey'}
 \description{
-\code{teal.osprey} provides community contributed \href{https://cran.r-project.org/package=teal}{\code{teal}} modules of the analysis functions from
-\code{osprey} package. See package \href{https://insightsengineering.github.io/osprey/}{website}.
+\code{teal.osprey} provides community contributed \href{https://cran.r-project.org/package=teal}{\code{teal}} modules of
+the analysis functions from \code{osprey} package. See package \href{https://insightsengineering.github.io/osprey/}{website}.
 This enables \code{teal} app developers to easily create applications making use of the \code{osprey} analysis functions.
 }
 \seealso{

--- a/man/teal.osprey-package.Rd
+++ b/man/teal.osprey-package.Rd
@@ -6,8 +6,8 @@
 \alias{teal.osprey-package}
 \title{\code{teal.osprey}: \code{teal} modules for 'osprey'}
 \description{
-\code{teal.osprey} provides community contributed \code{\link{teal}} modules of the analysis functions from
-\code{\link{osprey}} package. See package \href{https://insightsengineering.github.io/osprey/}{website}.
+\code{teal.osprey} provides community contributed \href{https://cran.r-project.org/package=teal}{\code{teal}} modules of the analysis functions from
+\code{osprey} package. See package \href{https://insightsengineering.github.io/osprey/}{website}.
 This enables \code{teal} app developers to easily create applications making use of the \code{osprey} analysis functions.
 }
 \seealso{


### PR DESCRIPTION
# Pull Request

Fixes #284 

I removed a link and resolved one manually to CRAN.
`R CMD check` doesn't complain (with 2024-12-07 r87428 ucrt).

Lintr didn't detect any issue

See https://github.com/insightsengineering/teal/issues/1420#issuecomment-2535506586 for a longer explanation.