### PR TITLE
Remove lookup-refs, vbump dependencies + add Remotes

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -42,20 +42,6 @@ jobs:
       unit-test-report-brand: >-
         https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/thumbs/teal.png
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/osprey
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/tern
-        insightsengineering/teal.logger
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.transform
-        insightsengineering/teal
   r-cmd-non-cran:
     name: R CMD Check (non-CRAN) 🧬
     uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
@@ -78,20 +64,6 @@ jobs:
         checking for unstated dependencies in vignettes .* NOTE
         checking top-level files .* NOTE
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/osprey
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/tern
-        insightsengineering/teal.logger
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.transform
-        insightsengineering/teal
   coverage:
     name: Coverage 📔
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main
@@ -101,20 +73,6 @@ jobs:
       additional-env-vars: |
         NOT_CRAN=true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/osprey
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/tern
-        insightsengineering/teal.logger
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.transform
-        insightsengineering/teal
   linter:
     if: github.event_name != 'push'
     name: SuperLinter 🦸‍♀️
@@ -127,20 +85,6 @@ jobs:
     with:
       auto-update: true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/osprey
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/tern
-        insightsengineering/teal.logger
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.transform
-        insightsengineering/teal
   gitleaks:
     name: gitleaks 💧
     uses: insightsengineering/r.pkg.template/.github/workflows/gitleaks.yaml@main

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -43,17 +43,3 @@ jobs:
       default-landing-page: latest-tag
       additional-unit-test-report-directories: unit-test-report-non-cran
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/osprey
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/tern
-        insightsengineering/teal.logger
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.transform
-        insightsengineering/teal

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,20 +17,6 @@ jobs:
     with:
       default-landing-page: latest-tag
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/osprey
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/tern
-        insightsengineering/teal.logger
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.transform
-        insightsengineering/teal
   validation:
     name: R Package Validation report 📃
     needs: release
@@ -39,20 +25,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/osprey
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/tern
-        insightsengineering/teal.logger
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.transform
-        insightsengineering/teal
   release:
     name: Create release 🎉
     uses: insightsengineering/r.pkg.template/.github/workflows/release.yaml@main
@@ -78,20 +50,6 @@ jobs:
       unit-test-report-brand: >-
         https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/thumbs/teal.png
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/osprey
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/tern
-        insightsengineering/teal.logger
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.transform
-        insightsengineering/teal
   coverage:
     name: Coverage 📔
     needs: [release, docs]
@@ -102,20 +60,6 @@ jobs:
       additional-env-vars: |
         NOT_CRAN=true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/osprey
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/tern
-        insightsengineering/teal.logger
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.transform
-        insightsengineering/teal
   wasm:
     name: Build WASM packages 🧑‍🏭
     needs: release

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -58,21 +58,6 @@ jobs:
       )
     name: revdepcheck ↩️
     uses: insightsengineering/r.pkg.template/.github/workflows/revdepcheck.yaml@main
-    with:
-      lookup-refs: |
-        insightsengineering/osprey
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/tern
-        insightsengineering/teal.logger
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.transform
-        insightsengineering/teal
   rhub:
     if: >
       github.event_name == 'schedule' || (
@@ -81,18 +66,3 @@ jobs:
       )
     name: R-hub 🌐
     uses: insightsengineering/r.pkg.template/.github/workflows/rhub.yaml@main
-    with:
-      lookup-refs: |
-        insightsengineering/osprey
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/tern
-        insightsengineering/teal.logger
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.transform
-        insightsengineering/teal

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,6 +47,7 @@ Suggests:
     testthat (>= 3.1.5),
     withr (>= 2.0.0)
 Remotes:
+    insightsengineering/osprey,
     insightsengineering/teal,
     insightsengineering/teal.transform,
     insightsengineering/teal.widgets

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     teal.data (>= 0.7.0),
     teal.logger (>= 0.3.1),
     teal.reporter (>= 0.4.0),
-    teal.widgets (>= 0.4.2.9025),
+    teal.widgets (>= 0.4.3),
     tern (>= 0.9.7),
     tidyr (>= 0.8.3)
 Suggests:
@@ -49,8 +49,7 @@ Suggests:
 Remotes:
     insightsengineering/osprey,
     insightsengineering/teal,
-    insightsengineering/teal.transform,
-    insightsengineering/teal.widgets
+    insightsengineering/teal.transform
 Config/Needs/verdepcheck: insightsengineering/osprey, rstudio/shiny,
     insightsengineering/teal, insightsengineering/teal.slice,
     insightsengineering/teal.transform, mllg/checkmate, tidyverse/dplyr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,10 +33,10 @@ Imports:
     ggplot2 (>= 3.4.0),
     lifecycle (>= 0.2.0),
     shinyvalidate,
-    teal.code (>= 0.5.0.9022),
-    teal.data (>= 0.6.0.9025),
-    teal.logger (>= 0.3.0.9004),
-    teal.reporter (>= 0.3.1.9023),
+    teal.code (>= 0.6.0),
+    teal.data (>= 0.7.0),
+    teal.logger (>= 0.3.1),
+    teal.reporter (>= 0.4.0),
     teal.widgets (>= 0.4.2.9025),
     tern (>= 0.9.7),
     tidyr (>= 0.8.3)
@@ -46,6 +46,10 @@ Suggests:
     rmarkdown (>= 2.23),
     testthat (>= 3.1.5),
     withr (>= 2.0.0)
+Remotes:
+    insightsengineering/teal,
+    insightsengineering/teal.transform,
+    insightsengineering/teal.widgets
 Config/Needs/verdepcheck: insightsengineering/osprey, rstudio/shiny,
     insightsengineering/teal, insightsengineering/teal.slice,
     insightsengineering/teal.transform, mllg/checkmate, tidyverse/dplyr,


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/609

From now on, we will provide development dependencies in 
```
Remotes: repo/project@branch
```
format, so it's explicitly visible in the DESCRIPTION file and can be handled by `pak::install`, `renv::install` and `remotes::install`.

With development dependencies specified in CJ Pipelines configuration, this connection was hidden, and it was hard to install the package from the main branch (or any other branch) locally from user's machine.