### PR TITLE
chore: bump teal.logger dependency to 0.4.0 and remove from Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     shinyvalidate,
     teal.code (>= 0.6.1),
     teal.data (>= 0.7.0),
-    teal.logger (>= 0.3.2.9001),
+    teal.logger (>= 0.4.0),
     teal.reporter (>= 0.4.0),
     teal.widgets (>= 0.4.3),
     tern (>= 0.9.7),
@@ -48,8 +48,7 @@ Suggests:
     testthat (>= 3.2.3),
     withr (>= 2.0.0)
 Remotes:
-    insightsengineering/osprey,
-    insightsengineering/teal.logger@main
+    insightsengineering/osprey
 Config/Needs/verdepcheck: insightsengineering/osprey, rstudio/shiny,
     insightsengineering/teal, insightsengineering/teal.slice,
     insightsengineering/teal.transform, mllg/checkmate, tidyverse/dplyr,


### PR DESCRIPTION
This PR updates all DESCRIPTION files to require teal.logger (>= 0.4.0) and removes it from Remotes.